### PR TITLE
ISOM 2017. Rework symbol set organization

### DIFF
--- a/symbol sets/src/ISOM_15000.xmap
+++ b/symbol sets/src/ISOM_15000.xmap
@@ -199,7 +199,7 @@
         </color>
     </colors>
     <barrier version="6" required="0.6.0">
-        <symbols count="161">
+        <symbols count="162">
             <symbol type="2" id="0" code="101" name="Contour">
                 <description>A line joining points of equal height. The standard vertical interval between contours is 5 metres. A contour interval of 2.5 metres may be used for flat terrains. The smallest bend in a contour is 0.25 mm from centre to centre of the lines.</description>
                 <line_symbol color="5" line_width="140" minimum_length="0" join_style="2" cap_style="1" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2491,7 +2491,15 @@ symbol.</description>
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="16" id="106" code="502.1" name="Road with two carriageways">
+            <symbol type="2" id="106" code="502.1" name="Wide road, 0.5mm width">
+                <description>Formerly &quot;502 Major road&quot;, provided for migration from ISOM 2000. Use of this symbol is discouraged for new maps.</description>
+                <line_symbol color="3" line_width="500" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
+                    <borders>
+                        <border color="4" width="140" shift="70" dash_length="2000" break_length="1000"/>
+                    </borders>
+                </line_symbol>
+            </symbol>
+            <symbol type="16" id="107" code="502.2" name="Road with two carriageways">
                 <description>A road with two carriageways can be represented using two wide road symbols side by side, keeping only one of the road edges in the middle. The width of the symbol should be drawn to scale but not smaller than the minimum width. The outer boundary lines may be replaced with other black line symbols, such as symbol 516 (fence), 518 (impassable fence), 513 (wall) or 515 (impassable wall) if the feature is so close to the road edge that it cannot practically be shown as a separate symbol.</description>
                 <combined_symbol parts="2">
                     <part private="true">
@@ -2510,38 +2518,38 @@ symbol.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="2" id="107" code="503" name="Road">
+            <symbol type="2" id="108" code="503" name="Road">
                 <description>A maintained road suitable for motor vehicles in all weather. Width less than 5 m.</description>
                 <line_symbol color="2" line_width="350" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="108" code="504" name="Vehicle track">
+            <symbol type="2" id="109" code="504" name="Vehicle track">
                 <description>A track or poorly maintained road suitable for vehicles only when travelling slowly.</description>
                 <line_symbol color="2" line_width="350" minimum_length="6250" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="3000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="109" code="505" name="Footpath">
+            <symbol type="2" id="110" code="505" name="Footpath">
                 <description>An easily runnable path, bicycle track or old vehicle track.</description>
                 <line_symbol color="2" line_width="250" minimum_length="4250" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="110" code="506" name="Small footpath">
+            <symbol type="2" id="111" code="506" name="Small footpath">
                 <description>A runnable small path or (temporary) forest extraction track which can be followed at competition speed.</description>
                 <line_symbol color="2" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="111" code="507" name="Less distinct small footpath">
+            <symbol type="2" id="112" code="507" name="Less distinct small footpath">
                 <description>A runnable less distinct / visible small path or forestry extraction track.</description>
                 <line_symbol color="2" line_width="180" minimum_length="5300" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1000" break_length="800" dashes_in_group="2" in_group_break_length="250" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="112" code="508" name="Narrow ride">
+            <symbol type="2" id="113" code="508" name="Narrow ride">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 Runnability: the same runnability as the surroundings.
 </description>
                 <line_symbol color="2" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="16" id="113" code="508.1" name="Narrow ride, yellow background">
+            <symbol type="16" id="114" code="508.1" name="Narrow ride, yellow background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: easy running.</description>
                 <combined_symbol parts="2">
-                    <part symbol="112"/>
+                    <part symbol="113"/>
                     <part private="true">
                         <symbol type="2" code="508.1.1" name="Yellow background">
                             <line_symbol color="17" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2549,12 +2557,12 @@ Runnability: easy running.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="114" code="508.2" name="Narrow ride, green 20% background">
+            <symbol type="16" id="115" code="508.2" name="Narrow ride, green 20% background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: slow running.</description>
                 <combined_symbol parts="2">
-                    <part symbol="112"/>
+                    <part symbol="113"/>
                     <part private="true">
                         <symbol type="2" code="508.2.1" name="Green 20% background">
                             <line_symbol color="16" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2562,12 +2570,12 @@ Runnability: slow running.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="115" code="508.3" name="Narrow ride, green 50% background">
+            <symbol type="16" id="116" code="508.3" name="Narrow ride, green 50% background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: walk.</description>
                 <combined_symbol parts="2">
-                    <part symbol="112"/>
+                    <part symbol="113"/>
                     <part private="true">
                         <symbol type="2" code="508.3.1" name="Green 50% background">
                             <line_symbol color="15" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2575,12 +2583,12 @@ Runnability: walk.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="116" code="508.4" name="Narrow ride, white background">
+            <symbol type="16" id="117" code="508.4" name="Narrow ride, white background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: normal runnability.</description>
                 <combined_symbol parts="2">
-                    <part symbol="112"/>
+                    <part symbol="113"/>
                     <part private="true">
                         <symbol type="2" code="508.4.1" name="White background">
                             <line_symbol color="13" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2588,7 +2596,7 @@ Runnability: normal runnability.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="117" code="509" name="Railway">
+            <symbol type="16" id="118" code="509" name="Railway">
                 <description>A railway or other kind of railed track.
 If it is forbidden to run along the railway, it shall be combined with the overprint symbol for forbidden route. If it is forbidden to cross the railway, it must be combined with a symbol for forbidden area.</description>
                 <combined_symbol parts="2">
@@ -2604,7 +2612,7 @@ If it is forbidden to run along the railway, it shall be combined with the overp
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="2" id="118" code="510" name="Power line">
+            <symbol type="2" id="119" code="510" name="Power line">
                 <description>Power line, cableway or skilift. The bars show the exact location of the pylons. The line may be broken to improve legibility.
 </description>
                 <line_symbol color="2" line_width="140" minimum_length="5000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2630,7 +2638,7 @@ If it is forbidden to run along the railway, it shall be combined with the overp
                     </dash_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="119" code="511" name="Major power line, minimum width">
+            <symbol type="2" id="120" code="511" name="Major power line, minimum width">
                 <description>Major power lines should be drawn with a double line. The gap between the lines may indicate the extent of the powerline.
 The lines may be broken to improve legibility. Very large carrying masts shall be represented in plan shape using symbol 521 (building) or with symbol 524 (high tower).</description>
                 <line_symbol color="-1" line_width="400" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2659,7 +2667,7 @@ The lines may be broken to improve legibility. Very large carrying masts shall b
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="120" code="511.1" name="Major power line">
+            <symbol type="2" id="121" code="511.1" name="Major power line">
                 <description>Major power lines should be drawn with a double line. The gap between the lines may indicate the extent of the powerline.
 The lines may be broken to improve legibility. Very large carrying masts shall be represented in plan shape using symbol 521 (building) or with symbol 524 (high tower).</description>
                 <line_symbol color="-1" line_width="1600" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2705,7 +2713,7 @@ The lines may be broken to improve legibility. Very large carrying masts shall b
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="121" code="512" name="Bridge / tunnel">
+            <symbol type="2" id="122" code="512" name="Bridge / tunnel">
                 <description>Bridges and tunnels are represented using the same basic symbols.
 If it is not possible to get through a tunnel (or under a bridge), it shall be omitted.
 Small bridges connected to a track/path are shown by centring a track dash on the crossing. Tracks/paths are broken for water course crossings without bridges.
@@ -2755,7 +2763,7 @@ Small bridges connected to a track/path are shown by centring a track dash on th
                     </end_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="122" code="512.0.1" name="Bridge / tunnel, minimum size">
+            <symbol type="1" id="123" code="512.0.1" name="Bridge / tunnel, minimum size">
                 <description>Bridges and tunnels are represented using the same basic symbols.
 If it is not possible to get through a tunnel (or under a bridge), it shall be omitted.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -2777,7 +2785,7 @@ If it is not possible to get through a tunnel (or under a bridge), it shall be o
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="123" code="512.1" name="Footbridge">
+            <symbol type="1" id="124" code="512.1" name="Footbridge">
                 <description>A small footbridge with no path leading to it is represented with a single dash.
 Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm over both sides of the stream!</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -2797,7 +2805,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="124" code="513" name="Wall">
+            <symbol type="2" id="125" code="513" name="Wall">
                 <description>A significant wall of stone, concrete, wood or other materials. Minimum height: 1 m.</description>
                 <line_symbol color="2" line_width="140" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -2807,7 +2815,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="125" code="514" name="Ruined stone wall">
+            <symbol type="2" id="126" code="514" name="Ruined stone wall">
                 <description>A ruined or less distinct wall. Minimum height 0.5 m.</description>
                 <line_symbol color="2" line_width="140" minimum_length="3650" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="2500" end_length="1250" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="350" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -2817,7 +2825,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="126" code="515" name="Impassable wall">
+            <symbol type="2" id="127" code="515" name="Impassable wall">
                 <description>An impassable or uncrossable wall, normally more than 1.5 m high.</description>
                 <line_symbol color="2" line_width="250" minimum_length="3000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="3000" end_length="1500" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="2" mid_symbol_distance="800">
                     <mid_symbol>
@@ -2827,7 +2835,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="127" code="516" name="Fence">
+            <symbol type="2" id="128" code="516" name="Fence">
                 <description>A wooden or wire fence less than ca. 1.5 m high.
 If the fence forms an enclosed area, tags should be placed inside.</description>
                 <line_symbol color="2" line_width="140" minimum_length="1500" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2853,7 +2861,7 @@ If the fence forms an enclosed area, tags should be placed inside.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="128" code="517" name="Ruined fence">
+            <symbol type="2" id="129" code="517" name="Ruined fence">
                 <description>A ruined or less distinct fence. If the fence forms an enclosed area, tags should be placed inside.</description>
                 <line_symbol color="2" line_width="140" minimum_length="3650" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="2500" end_length="1250" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="350" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -2878,7 +2886,7 @@ If the fence forms an enclosed area, tags should be placed inside.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="129" code="518" name="Impassable fence">
+            <symbol type="2" id="130" code="518" name="Impassable fence">
                 <description>An impassable or uncrossable fence, normally more than 1.5 m high.
 If the fence forms an enclosed area, tags should be placed inside.</description>
                 <line_symbol color="2" line_width="250" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2500" end_length="1250" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2918,7 +2926,7 @@ If the fence forms an enclosed area, tags should be placed inside.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="130" code="519" name="Crossing point">
+            <symbol type="1" id="131" code="519" name="Crossing point">
                 <description>A way through or over a wall, fence or other linear feature, including a gate or stile.
 For impassable features, the line shall be broken at the crossing point. For passable features, the line shall not be broken if passing involves a degree of climb.
 </description>
@@ -2953,33 +2961,33 @@ For impassable features, the line shall be broken at the crossing point. For pas
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="4" id="131" code="520.0" name="Area that shall not be entered">
+            <symbol type="4" id="132" code="520.0" name="Area that shall not be entered">
                 <description>An out-of-bounds area is a feature such as a private house, a garden, a factory or another industrial area. Only contours and prominent features such as railways and large buildings shall be shown inside an out-of-bounds area.
 The area shall be discontinued where a path or track goes through. Out-of-bounds areas should be bounded by the black boundary line or another black line symbol (e.g. fence).
 </description>
                 <area_symbol inner_color="12" min_area="1000" patterns="0"/>
             </symbol>
-            <symbol type="2" id="132" code="520.0.1" name="Out of bounds area, bounding line">
+            <symbol type="2" id="133" code="520.0.1" name="Out of bounds area, bounding line">
                 <description>A bounding line may be drawn with 520.0 if there is no natural boundary.</description>
                 <line_symbol color="2" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="133" code="520.1" name="Area that shall not be entered, alternative">
+            <symbol type="4" id="134" code="520.1" name="Area that shall not be entered, alternative">
                 <description>An out-of-bounds area is a feature such as a private house, a garden, a factory or another industrial area. Only contours and prominent features such as railways and large buildings shall be shown inside an out-of-bounds area.
 Vertical black stripes may be used for areas where it is important to show a complete representation of the terrain (e.g. when a part of the forest is out-of-bounds). The area shall be discontinued where a path or track goes through. Out-of-bounds areas should be bounded by the black boundary line or another black line symbol (e.g. fence).</description>
                 <area_symbol inner_color="-1" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" line_spacing="750" line_offset="0" offset_along_line="0" color="2" line_width="250"/>
                 </area_symbol>
             </symbol>
-            <symbol type="2" id="134" code="520.1.1" name="Out of bounds area, alternative bounding line">
+            <symbol type="2" id="135" code="520.1.1" name="Out of bounds area, alternative bounding line">
                 <description>A bounding line may be drawn with 520.1 if there is no natural boundary.</description>
                 <line_symbol color="2" line_width="350" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="135" code="521" name="Building">
+            <symbol type="4" id="136" code="521" name="Building">
                 <description>A building is shown with its ground plan so far as the scale permits.
 Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m). Buildings within forbidden areas are generalised. Areas totally contained within a building shall not be mapped (they shall be represented as being part of the building). Minimum gap indicating a passage between buildings and between buildings and other impassable features should be 0.25 mm.</description>
                 <area_symbol inner_color="2" min_area="300" patterns="0"/>
             </symbol>
-            <symbol type="1" id="136" code="521.0.1" name="Building, minimum size">
+            <symbol type="1" id="137" code="521.0.1" name="Building, minimum size">
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
                         <symbol type="4" code="">
@@ -3000,43 +3008,43 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="16" id="137" code="521.1" name="Large building with outline">
+            <symbol type="16" id="138" code="521.1" name="Large building with outline">
                 <description>A building is shown with its ground plan so far as the scale permits.
 Buildings larger than 75 m x 75 m may be represented with a dark grey infill in urban areas.
 Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m). Buildings within forbidden areas are generalised. Areas totally contained within a building shall not be mapped (they shall be represented as being part of the building). Minimum gap indicating a passage between buildings and between buildings and other impassable features should be 0.25 mm.</description>
                 <combined_symbol parts="2">
-                    <part symbol="138"/>
                     <part symbol="139"/>
+                    <part symbol="140"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="138" code="521.1.1" name="Large building">
+            <symbol type="4" id="139" code="521.1.1" name="Large building">
                 <description>Buildings larger than 75 m x 75 m may be represented with a dark grey infill in urban areas.</description>
                 <area_symbol inner_color="6" min_area="0" patterns="0"/>
             </symbol>
-            <symbol type="2" id="139" code="521.1.2" name="Large building outline">
+            <symbol type="2" id="140" code="521.1.2" name="Large building outline">
                 <description>A black line surrounds the symbol 521.1.1.</description>
                 <line_symbol color="2" line_width="200" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="16" id="140" code="522" name="Canopy with outline">
+            <symbol type="16" id="141" code="522" name="Canopy with outline">
                 <description>An accessible and runnable area with roof.</description>
                 <combined_symbol parts="2">
-                    <part symbol="141"/>
                     <part symbol="142"/>
+                    <part symbol="143"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="141" code="522.0.1" name="Canopy">
+            <symbol type="4" id="142" code="522.0.1" name="Canopy">
                 <description>An accessible and runnable area with roof.</description>
                 <area_symbol inner_color="8" min_area="400" patterns="0"/>
             </symbol>
-            <symbol type="2" id="142" code="522.0.2" name="Canopy outline">
+            <symbol type="2" id="143" code="522.0.2" name="Canopy outline">
                 <description>A black line surrounds the symbol 522.0.1.</description>
                 <line_symbol color="2" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="143" code="523" name="Ruin">
+            <symbol type="2" id="144" code="523" name="Ruin">
                 <description>A ruined building. The ground plan of a ruin is shown to scale, down to the minimum size.</description>
                 <line_symbol color="2" line_width="160" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="500" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="1" id="144" code="523.0.1" name="Ruin, minimum size">
+            <symbol type="1" id="145" code="523.0.1" name="Ruin, minimum size">
                 <description>Ruins that are so small that they cannot be drawn to scale may be represented using a solid line.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -3058,7 +3066,7 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="145" code="524" name="High tower">
+            <symbol type="1" id="146" code="524" name="High tower">
                 <description>A high tower or large pylon. If it is in a forest, it must be visible above the level of the surrounding forest.</description>
                 <point_symbol inner_radius="400" inner_color="2" outer_width="0" outer_color="-1" elements="2">
                     <element>
@@ -3091,7 +3099,7 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="146" code="525" name="Small tower">
+            <symbol type="1" id="147" code="525" name="Small tower">
                 <description>An obvious small tower, platform or seat.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
                     <element>
@@ -3124,7 +3132,7 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="147" code="526" name="Cairn">
+            <symbol type="1" id="148" code="526" name="Cairn">
                 <description>A prominent cairn, memorial stone, boundary stone or trigonometric point.
 Minimum height: 0.5 m.</description>
                 <point_symbol inner_radius="70" inner_color="2" outer_width="0" outer_color="-1" elements="1">
@@ -3140,7 +3148,7 @@ Minimum height: 0.5 m.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="148" code="527" name="Fodder rack">
+            <symbol type="1" id="149" code="527" name="Fodder rack">
                 <description>A fodder rack, which is free standing or attached to a tree.
 Location is at the centre of gravity of the symbol.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
@@ -3175,7 +3183,7 @@ Location is at the centre of gravity of the symbol.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="149" code="528" name="Prominent line feature">
+            <symbol type="2" id="150" code="528" name="Prominent line feature">
                 <description>A prominent man-made line feature. For example, a low pipeline (gas, water, oil, heat, etc.) or a bobsleigh/skeleton track that is clearly visible. The definition of the symbol must be given on the map.</description>
                 <line_symbol color="2" line_width="140" minimum_length="1500" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -3214,7 +3222,7 @@ Location is at the centre of gravity of the symbol.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="150" code="529" name="Prominent impassable line feature">
+            <symbol type="2" id="151" code="529" name="Prominent impassable line feature">
                 <description>An impassable man-made line feature. For example, a high pipeline (gas, water, oil, heat, etc.) or a bobsleigh/skeleton track. The definition of the symbol must be given on the map.</description>
                 <line_symbol color="2" line_width="250" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="2" mid_symbol_distance="600">
                     <mid_symbol>
@@ -3253,13 +3261,13 @@ Location is at the centre of gravity of the symbol.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="151" code="530" name="Prominent man-made feature – ring">
+            <symbol type="1" id="152" code="530" name="Prominent man-made feature – ring">
                 <description>Special man-made features are shown with these symbols. The definition of the
 symbols must be given in each case in the map legend.
 </description>
                 <point_symbol inner_radius="240" inner_color="-1" outer_width="160" outer_color="2" elements="0"/>
             </symbol>
-            <symbol type="1" id="152" code="531" name="Prominent man-made feature – x">
+            <symbol type="1" id="153" code="531" name="Prominent man-made feature – x">
                 <description>Special man-made features are shown with these symbols. The definition of the
 symbols must be given in each case in the map legend.
 </description>
@@ -3294,30 +3302,30 @@ symbols must be given in each case in the map legend.
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="153" code="601.1" name="Magnetic north line">
+            <symbol type="2" id="154" code="601.1" name="Magnetic north line">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.
 </description>
                 <line_symbol color="2" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="154" code="601.1.1" name="North lines pattern">
+            <symbol type="4" id="155" code="601.1.1" name="North lines pattern">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="20000" line_offset="0" offset_along_line="0" color="2" line_width="100"/>
                 </area_symbol>
             </symbol>
-            <symbol type="2" id="155" code="601.2" name="Magnetic north line, blue">
+            <symbol type="2" id="156" code="601.2" name="Magnetic north line, blue">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.</description>
                 <line_symbol color="10" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="156" code="601.2.1" name="North lines pattern, blue">
+            <symbol type="4" id="157" code="601.2.1" name="North lines pattern, blue">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="20000" line_offset="0" offset_along_line="0" color="10" line_width="180"/>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="157" code="602" name="Registration mark">
+            <symbol type="1" id="158" code="602" name="Registration mark">
                 <description>At least three registration marks should be placed within the frame of a map in a non-symmetrical position. These can be used for course overprinting when overprinting on already printed maps. In addition, it allows a check of colour registration when printing colours separately.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
                     <element>
@@ -3350,18 +3358,18 @@ symbols must be given in each case in the map legend.
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="158" code="603.0" name="Spot height, dot">
+            <symbol type="1" id="159" code="603.0" name="Spot height, dot">
                 <description>Spot heights are used for the rough assessment of height differences. The height is given to the nearest metre. Water levels are given without the dot. Spot heights must only be used where they do not conflict with other symbols.</description>
                 <point_symbol inner_radius="150" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="8" id="159" code="603.1" name="Spot height, text">
+            <symbol type="8" id="160" code="603.1" name="Spot height, text">
                 <description>Spot heights are used for the rough assessment of height differences. The height is given to the nearest metre. Water levels are given without the dot. Spot heights must only be used where they do not conflict with other symbols.</description>
                 <text_symbol icon_text="321">
                     <font family="Arial" size="2180"/>
                     <text color="2" line_spacing="1" paragraph_spacing="0" character_spacing="0" kerning="true"/>
                 </text_symbol>
             </symbol>
-            <symbol type="1" id="160" code="999" name="OpenOrienteering Logo">
+            <symbol type="1" id="161" code="999" name="OpenOrienteering Logo">
                 <description>The OpenOrienteering Logo.</description>
                 <point_symbol inner_radius="250" inner_color="-1" outer_width="0" outer_color="-1" elements="30">
                     <element>
@@ -7611,7 +7619,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="131">
+                    <object type="1" symbol="132">
                         <coords count="13">
                             <coord x="-7716" y="-35085" flags="1"/>
                             <coord x="-8039" y="-34658"/>
@@ -7748,7 +7756,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="0" symbol="157">
+                    <object type="0" symbol="158">
                         <coords count="1">
                             <coord x="-3723" y="-27231"/>
                         </coords>
@@ -7825,7 +7833,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="112">
+                    <object type="1" symbol="113">
                         <coords count="2">
                             <coord x="-3681" y="-31114"/>
                             <coord x="-2662" y="-27426" flags="16"/>
@@ -7834,7 +7842,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="113">
+                    <object type="1" symbol="114">
                         <coords count="2">
                             <coord x="-3182" y="-31394"/>
                             <coord x="-1828" y="-27460"/>
@@ -7843,7 +7851,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="114">
+                    <object type="1" symbol="115">
                         <coords count="2">
                             <coord x="-2533" y="-31719"/>
                             <coord x="-1016" y="-27433"/>
@@ -7852,7 +7860,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="115">
+                    <object type="1" symbol="116">
                         <coords count="2">
                             <coord x="-2071" y="-32056"/>
                             <coord x="-169" y="-27772"/>
@@ -7861,7 +7869,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="116">
+                    <object type="1" symbol="117">
                         <coords count="2">
                             <coord x="-1479" y="-32352"/>
                             <coord x="558" y="-28125"/>
@@ -7959,16 +7967,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="105">
-                        <coords count="2">
-                            <coord x="-14964" y="-26565"/>
-                            <coord x="-5684" y="-26604"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="156">
+                    <object type="1" symbol="157">
                         <coords count="5">
                             <coord x="-24396" y="-35893" flags="32"/>
                             <coord x="-24260" y="-9966" flags="32"/>
@@ -7980,7 +7979,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="106">
+                    <object type="1" symbol="107">
                         <coords count="2">
                             <coord x="-4270" y="-26389"/>
                             <coord x="1990" y="-26416" flags="16"/>
@@ -7995,8 +7994,17 @@ symbols must be given in each case in the map legend.
                             <coord x="-4266" y="-26780"/>
                             <coord x="-4257" y="-25999"/>
                             <coord x="-4567" y="-25994"/>
-                            <coord x="-5815" y="-26455"/>
+                            <coord x="-5805" y="-26251"/>
                             <coord x="-5814" y="-26753" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="106">
+                        <coords count="2">
+                            <coord x="-14971" y="-26463"/>
+                            <coord x="-5691" y="-26502"/>
                         </coords>
                         <pattern rotation="0">
                             <coord x="0" y="0"/>

--- a/symbol sets/src/ISOM_15000.xmap
+++ b/symbol sets/src/ISOM_15000.xmap
@@ -199,86 +199,12 @@
         </color>
     </colors>
     <barrier version="6" required="0.6.0">
-        <symbols count="168">
+        <symbols count="161">
             <symbol type="2" id="0" code="101" name="Contour">
                 <description>A line joining points of equal height. The standard vertical interval between contours is 5 metres. A contour interval of 2.5 metres may be used for flat terrains. The smallest bend in a contour is 0.25 mm from centre to centre of the lines.</description>
                 <line_symbol color="5" line_width="140" minimum_length="0" join_style="2" cap_style="1" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="1" id="1" code="101.0.1" name="Knoll, minimum size">
-                <description>The minimum length of a contour knoll is 0.9 mm (footprint 13.5 m) and the minimum width is 0.6 mm (footprint 9 m) outside measure. Smaller prominent knolls can be represented using symbol 109 (small knoll) or symbol 110 (small elongated knoll) or they can be exaggerated on the map to satisfy the minimum dimension.</description>
-                <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="5" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="800" segment_length="3200" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="3200" break_length="800" dashes_in_group="1" in_group_break_length="400" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="13">
-                                <coord x="0" y="-384" flags="1"/>
-                                <coord x="160" y="-384"/>
-                                <coord x="224" y="-240"/>
-                                <coord x="224" y="0" flags="1"/>
-                                <coord x="224" y="240"/>
-                                <coord x="160" y="384"/>
-                                <coord x="0" y="384" flags="1"/>
-                                <coord x="-160" y="384"/>
-                                <coord x="-224" y="240"/>
-                                <coord x="-224" y="0" flags="1"/>
-                                <coord x="-224" y="-240"/>
-                                <coord x="-160" y="-384"/>
-                                <coord x="0" y="-384" flags="18"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                </point_symbol>
-            </symbol>
-            <symbol type="1" id="2" code="101.0.2" name="Depression, minimum size">
-                <description>A depression must accommodate a slope line, so the minimum length is 1.1 mm (footprint 16.5 m) and the minimum width is 0.7 mm (footprint 10.5 m) outside measure. Smaller, prominent depressions can be represented using symbol 111 (small depression) or they can be exaggerated to satisfy the minimum dimension.</description>
-                <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="5" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="13">
-                                <coord x="0" y="-480" flags="1"/>
-                                <coord x="200" y="-480"/>
-                                <coord x="280" y="-300"/>
-                                <coord x="280" y="0" flags="1"/>
-                                <coord x="280" y="300"/>
-                                <coord x="200" y="480"/>
-                                <coord x="0" y="480" flags="1"/>
-                                <coord x="-200" y="480"/>
-                                <coord x="-280" y="300"/>
-                                <coord x="-280" y="0" flags="1"/>
-                                <coord x="-280" y="-300"/>
-                                <coord x="-200" y="-480"/>
-                                <coord x="0" y="-480" flags="18"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="5" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="2">
-                                <coord x="0" y="480"/>
-                                <coord x="0" y="10"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                </point_symbol>
-            </symbol>
-            <symbol type="1" id="3" code="101.1" name="Slope line, contour">
+            <symbol type="1" id="1" code="101.1" name="Slope line, contour">
                 <description>Slope lines may be drawn on the lower side of a contour line to clarify the direction of slope. When used, they should be placed in re-entrants.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -297,68 +223,23 @@
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="4" code="102" name="Index contour">
+            <symbol type="2" id="2" code="102" name="Index contour">
                 <description>Every fifth contour shall be drawn with a thicker line. This is an aid to the quick assessment of height difference and the overall shape of the terrain surface. An index contour may be represented as an ordinary contour line in an area with much detail. Small contour knolls and depressions are normally not represented using index contours.</description>
                 <line_symbol color="5" line_width="250" minimum_length="0" join_style="2" cap_style="1" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="8" id="5" code="102.1" name="Contour value">
+            <symbol type="8" id="3" code="102.1" name="Contour value">
                 <description>Contour values may be included to aid assessment of large height differences. They are inserted in the index contours in positions where other detail is not obscured. The figures should be orientated so that the top of the figure is on the higher side of the contour.</description>
                 <text_symbol icon_text="225">
                     <font family="Arial" size="2076"/>
                     <text color="5" line_spacing="1" paragraph_spacing="0" character_spacing="0" kerning="true"/>
                 </text_symbol>
             </symbol>
-            <symbol type="2" id="6" code="103" name="Form line">
+            <symbol type="2" id="4" code="103" name="Form line">
                 <description>Form lines are used where more information must be given about the shape of the ground. Form lines are added only where representation would be incomplete with ordinary contours. They shall not be used as intermediate contours. Only one form line should be used between neighbouring contours. It is very important that a form line fits logically into the contour system, so the start and end of a form line should be parallel to the neighbouring contours. The gaps between the form line dashes must be placed on reasonably straight sections of the form line. Form lines can be used to differentiate flat knolls and depressions from more distinct ones.
 </description>
                 <line_symbol color="5" line_width="100" minimum_length="0" join_style="2" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="200" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="1" id="7" code="103.0.1" name="Flat depression or knoll, minimum size">
-                <description>Form lines can be used to differentiate flat knolls and depressions from more distinct ones (minimum height/depth should be 1 m).
-Use 103.1 (Slope line for formline) to display depression or knoll
-Minimum length of a form line knoll or depression: 1.1 mm (footprint 16.5 m) outside measure.</description>
-                <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="5" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="7">
-                                <coord x="300" y="100" flags="1"/>
-                                <coord x="300" y="300"/>
-                                <coord x="200" y="500"/>
-                                <coord x="0" y="500" flags="1"/>
-                                <coord x="-200" y="500"/>
-                                <coord x="-300" y="300"/>
-                                <coord x="-300" y="100" flags="16"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="5" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="7">
-                                <coord x="300" y="-100" flags="1"/>
-                                <coord x="300" y="-300"/>
-                                <coord x="200" y="-500"/>
-                                <coord x="0" y="-500" flags="1"/>
-                                <coord x="-200" y="-500"/>
-                                <coord x="-300" y="-300"/>
-                                <coord x="-300" y="-100"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                </point_symbol>
-            </symbol>
-            <symbol type="1" id="8" code="103.1" name="Slope line, formline">
+            <symbol type="1" id="5" code="103.1" name="Slope line, formline">
                 <description>Slope lines may be drawn on the lower side of a contour line to clarify the direction of slope. When used, they should be placed in re-entrants.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -377,9 +258,29 @@ Minimum length of a form line knoll or depression: 1.1 mm (footprint 16.5 m) out
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="9" code="104" name="Earth bank">
+            <symbol type="2" id="6" code="104" name="Earth bank">
                 <description>An earth bank is an abrupt change in ground level which can be clearly distinguished from its surroundings, e.g. gravel or sand pits, road and railway cuttings or embankments. Minimum height: 1 m. An earth bank may impact runnability. The tags represent the full extent of the earth bank. For long earth banks it is allowed to use tags shorter than the minimum length at the ends. If two earth banks are close together, tags may be omitted. Impassable earth banks shall be represented using symbol 201 (impassable cliff).</description>
-                <line_symbol color="5" line_width="180" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="500" end_length="280" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
+                <line_symbol color="5" line_width="180" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="500" end_length="570" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
+                    <start_symbol>
+                        <symbol type="1" code="" name="Start symbol">
+                            <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
+                                <element>
+                                    <symbol type="2" code="">
+                                        <line_symbol color="5" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+                                    </symbol>
+                                    <object type="1">
+                                        <coords count="2">
+                                            <coord x="70" y="0"/>
+                                            <coord x="70" y="490"/>
+                                        </coords>
+                                        <pattern rotation="0">
+                                            <coord x="0" y="0"/>
+                                        </pattern>
+                                    </object>
+                                </element>
+                            </point_symbol>
+                        </symbol>
+                    </start_symbol>
                     <mid_symbol>
                         <symbol type="1" code="" name="Mid symbol">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -400,9 +301,29 @@ Minimum length of a form line knoll or depression: 1.1 mm (footprint 16.5 m) out
                             </point_symbol>
                         </symbol>
                     </mid_symbol>
+                    <end_symbol>
+                        <symbol type="1" code="" name="End symbol">
+                            <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
+                                <element>
+                                    <symbol type="2" code="">
+                                        <line_symbol color="5" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+                                    </symbol>
+                                    <object type="1">
+                                        <coords count="2">
+                                            <coord x="-70" y="0"/>
+                                            <coord x="-70" y="490"/>
+                                        </coords>
+                                        <pattern rotation="0">
+                                            <coord x="0" y="0"/>
+                                        </pattern>
+                                    </object>
+                                </element>
+                            </point_symbol>
+                        </symbol>
+                    </end_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="10" code="104.0.1" name="Earth bank, minimum size">
+            <symbol type="1" id="7" code="104.0.1" name="Earth bank, minimum size">
                 <description>An earth bank is an abrupt change in ground level which can be clearly distinguished from its surroundings, e.g. gravel or sand pits, road and railway cuttings or embankments. Minimum height: 1 m. An earth bank may impact runnability. The tags represent the full extent of the earth bank. For long earth banks it is allowed to use tags shorter than the minimum length at the ends. If two earth banks are close together, tags may be omitted. Impassable earth banks shall be represented using symbol 201 (impassable cliff).</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="3">
                     <element>
@@ -449,11 +370,15 @@ Minimum length of a form line knoll or depression: 1.1 mm (footprint 16.5 m) out
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="11" code="104.1" name="Earth bank, tag line">
+            <symbol type="2" id="8" code="104.1" name="Earth bank, top line">
+                <description>An earth bank is an abrupt change in ground level which can be clearly distinguished from its surroundings, e.g. gravel or sand pits, road and railway cuttings or embankments. Minimum height: 1 m. An earth bank may impact runnability. The tags represent the full extent of the earth bank. For long earth banks it is allowed to use tags shorter than the minimum length at the ends. If two earth banks are close together, tags may be omitted. Impassable earth banks shall be represented using symbol 201 (impassable cliff).</description>
+                <line_symbol color="5" line_width="180" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="500" end_length="570" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+            </symbol>
+            <symbol type="2" id="9" code="104.2" name="Earth bank, tag line">
                 <description>Use this symbol to display the full extent of wide earth banks.</description>
                 <line_symbol color="5" line_width="140" minimum_length="400" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="12" code="105" name="Earth wall">
+            <symbol type="2" id="10" code="105" name="Earth wall">
                 <description>Distinct earth wall. Minimum height is 1 m.</description>
                 <line_symbol color="5" line_width="180" minimum_length="0" join_style="2" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -463,7 +388,7 @@ Minimum length of a form line knoll or depression: 1.1 mm (footprint 16.5 m) out
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="13" code="106" name="Small earth wall">
+            <symbol type="2" id="11" code="106" name="Small earth wall">
                 <description>A small or partly ruined earth wall shall be shown with a dashed line. Minimum height is 0.5 m.</description>
                 <line_symbol color="5" line_width="180" minimum_length="3650" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="350" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -473,12 +398,12 @@ Minimum length of a form line knoll or depression: 1.1 mm (footprint 16.5 m) out
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="14" code="107" name="Erosion gully">
+            <symbol type="2" id="12" code="107" name="Erosion gully">
                 <description>An erosion gully which is too small to be shown using symbol 104 (earth bank) is shown by a single line. Minimum depth: 1 m.
 Contour lines shall not be broken around this symbol.</description>
                 <line_symbol color="5" line_width="250" minimum_length="1600" join_style="2" cap_style="3" pointed_cap_length="747" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="15" code="108" name="Small erosion gully">
+            <symbol type="2" id="13" code="108" name="Small erosion gully">
                 <description>A small erosion gully, dry ditch or trench. Minimum depth: 0.5 m.
 Contour lines should be broken around this symbol.</description>
                 <line_symbol color="-1" line_width="0" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="450" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -489,12 +414,12 @@ Contour lines should be broken around this symbol.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="16" code="109" name="Small knoll">
+            <symbol type="1" id="14" code="109" name="Small knoll">
                 <description>An obvious mound or knoll which cannot be drawn to scale with a contour. Minimum height: 1 m.
 The symbol shall not touch or overlap contours.</description>
                 <point_symbol inner_radius="250" inner_color="5" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="1" id="17" code="110" name="Small elongated knoll">
+            <symbol type="1" id="15" code="110" name="Small elongated knoll">
                 <description>An obvious elongated knoll which cannot be drawn to scale with a contour. Minimum height: 1 m.
 The symbol shall not touch or overlap contours.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -525,7 +450,7 @@ The symbol shall not touch or overlap contours.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="18" code="111" name="Small depression">
+            <symbol type="1" id="16" code="111" name="Small depression">
                 <description>A small depression or hollow without steep sides that is too small to be shown by contours. Minimum depth: 1 m. Minimum width: 2 m.
 Small depressions with steep sides are represented with symbol 112 (pit). The symbol may not touch or overlap other brown symbols. Location is the centre of gravity of the symbol, and the symbol is orientated to north.
 </description>
@@ -551,7 +476,7 @@ Small depressions with steep sides are represented with symbol 112 (pit). The sy
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="19" code="112" name="Pit">
+            <symbol type="1" id="17" code="112" name="Pit">
                 <description>Pits and holes with distinct steep sides which cannot be shown to scale using symbol 104 (earth bank). Minimum depth: 1 m. Minimum width: 1 m. A pit larger than 5 m x 5 m should normally be exaggerated and drawn using symbol 104 (earth bank). Pits without steep sides are represented with symbol 111 (small depression). The symbol may not touch or overlap other brown symbols. Location is the centre of
 gravity of the symbol, and the symbol is orientated to north.</description>
                 <point_symbol inner_radius="900" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -576,14 +501,14 @@ gravity of the symbol, and the symbol is orientated to north.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="4" id="20" code="113" name="Broken ground">
+            <symbol type="4" id="18" code="113" name="Broken ground">
                 <description>An area of pits and/or knolls which is too intricate to be shown in detail, or other types of rough and uneven ground that is clearly distinguishable but has little impact on runnability.
 This is an area symbol.
 The minimum number of dots is three (footprint 10 m x 10 m).
 Contours shall not be cut in broken ground areas.
 Density: 3 to 5 dots / mm2 (9-16%).</description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="4">
                                 <element>
@@ -631,11 +556,11 @@ Density: 3 to 5 dots / mm2 (9-16%).</description>
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="21" code="113.1" name="Broken ground, individual dot">
+            <symbol type="1" id="19" code="113.1" name="Broken ground, individual dot">
                 <description>An area of pits or knolls which is too intricate to be shown in detail. The density of randomly placed dots may vary according to the detail on the ground.</description>
                 <point_symbol inner_radius="100" inner_color="5" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="4" id="22" code="114" name="Very broken ground">
+            <symbol type="4" id="20" code="114" name="Very broken ground">
                 <description>An area of pits and/or knolls, which is too intricate to be shown in detail, or other types of rough and uneven ground that is clearly distinguishable and affects runnability.
 This is an area symbol.
 The minimum number of dots is three (footprint 7m x 7m).
@@ -643,7 +568,7 @@ Contours shall not be cut in broken ground areas.
 Density: 8 to 10 dots / mm2 (25-32%).
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="9">
                                 <element>
@@ -741,7 +666,7 @@ Density: 8 to 10 dots / mm2 (25-32%).
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="23" code="115" name="Prominent landform feature">
+            <symbol type="1" id="21" code="115" name="Prominent landform feature">
                 <description>The feature must be very clearly distinguishable from its surroundings. Location is the centre of gravity of the symbol, which is orientated to north. The symbol may not touch or overlap other brown symbols.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -762,7 +687,7 @@ Density: 8 to 10 dots / mm2 (25-32%).
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="24" code="201" name="Impassable cliff">
+            <symbol type="2" id="22" code="201" name="Impassable cliff">
                 <description>A cliff, quarry or earth bank that is so high and steep that it is impossible to pass/climb or is dangerous.
 For vertical rock faces the tags may be omitted if space is short. Ends of the top line may be rounded or square. For plan shape representation, the minimum width is 0.35 mm. Shorter tags may be used at the ends.
 The gap between two impassable cliffs or between impassable cliffs and other impassable feature symbols must exceed 0.3 mm on the map.
@@ -831,7 +756,7 @@ When an impassable cliff drops straight into water, making it impossible to pass
                     </end_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="25" code="201.0.1" name="Impassable cliff, minimum size">
+            <symbol type="1" id="23" code="201.0.1" name="Impassable cliff, minimum size">
                 <description>A cliff, quarry or earth bank that is so high and steep that it is impossible to pass/climb or is dangerous.
 For vertical rock faces the tags may be omitted if space is short. Ends of the top line may be rounded or square. For plan shape representation, the minimum width is 0.35 mm. Shorter tags may be used at the ends.
 The gap between two impassable cliffs or between impassable cliffs and other impassable feature symbols must exceed 0.3 mm on the map.
@@ -881,20 +806,63 @@ When an impassable cliff drops straight into water, making it impossible to pass
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="26" code="201.1" name="Impassable cliff, no tags">
+            <symbol type="2" id="24" code="201.1" name="Impassable cliff, top line">
                 <description>For vertical rock faces the tags may be omitted if space is short, e.g. narrow passages between cliffs (the passage should be drawn with a width of at least 0.3 mm).</description>
                 <line_symbol color="2" line_width="350" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="600" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="27" code="201.2" name="Impassable cliff, tag line">
+            <symbol type="2" id="25" code="201.2" name="Impassable cliff, tag line">
                 <description>Use this symbol to display the full extent of a wide cliff.</description>
                 <line_symbol color="2" line_width="120" minimum_length="500" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="28" code="202" name="Cliff">
+            <symbol type="2" id="26" code="202" name="Cliff, no tags">
+                <description>Should be used if the direction of fall of the rock face is apparent from the contours and the legibility is good.</description>
+                <line_symbol color="2" line_width="200" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+            </symbol>
+            <symbol type="1" id="27" code="202.0.1" name="Cliff, no tags, minimum size">
+                <description>Should be used if the direction of fall of the rock face is apparent from the contours and the legibility is good.</description>
+                <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
+                    <element>
+                        <symbol type="2" code="">
+                            <line_symbol color="2" line_width="200" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+                        </symbol>
+                        <object type="1">
+                            <coords count="2">
+                                <coord x="-300" y="0"/>
+                                <coord x="300" y="0"/>
+                            </coords>
+                            <pattern rotation="0">
+                                <coord x="0" y="0"/>
+                            </pattern>
+                        </object>
+                    </element>
+                </point_symbol>
+            </symbol>
+            <symbol type="2" id="28" code="202.1" name="Cliff, with tags">
                 <description>A passable cliff or quarry. Minimum height: 1 m.
 If the direction of fall of the cliff is not apparent from the contours, or to improve legibility, short tags may be drawn in the direction of the downslope.
 For non-vertical cliffs, the tags should be drawn to show the full horizontal extent. Ends of the top line may be rounded or square. A passage between two cliffs must be at least 0.2 mm. A cliff should interplay with the contour lines.
 Crossing a cliff will normally slow progress.</description>
-                <line_symbol color="2" line_width="200" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="500" end_length="280" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
+                <line_symbol color="2" line_width="200" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="500" end_length="560" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
+                    <start_symbol>
+                        <symbol type="1" code="" name="Start symbol">
+                            <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
+                                <element>
+                                    <symbol type="2" code="">
+                                        <line_symbol color="2" line_width="120" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+                                    </symbol>
+                                    <object type="1">
+                                        <coords count="2">
+                                            <coord x="60" y="0"/>
+                                            <coord x="60" y="500"/>
+                                        </coords>
+                                        <pattern rotation="0">
+                                            <coord x="0" y="0"/>
+                                        </pattern>
+                                    </object>
+                                </element>
+                            </point_symbol>
+                        </symbol>
+                    </start_symbol>
                     <mid_symbol>
                         <symbol type="1" code="" name="Mid symbol">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -915,9 +883,29 @@ Crossing a cliff will normally slow progress.</description>
                             </point_symbol>
                         </symbol>
                     </mid_symbol>
+                    <end_symbol>
+                        <symbol type="1" code="" name="End symbol">
+                            <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
+                                <element>
+                                    <symbol type="2" code="">
+                                        <line_symbol color="2" line_width="120" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
+                                    </symbol>
+                                    <object type="1">
+                                        <coords count="2">
+                                            <coord x="-60" y="0"/>
+                                            <coord x="-60" y="500"/>
+                                        </coords>
+                                        <pattern rotation="0">
+                                            <coord x="0" y="0"/>
+                                        </pattern>
+                                    </object>
+                                </element>
+                            </point_symbol>
+                        </symbol>
+                    </end_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="29" code="202.0.1" name="Cliff, minimum size">
+            <symbol type="1" id="29" code="202.1.1" name="Cliff, minimum size">
                 <description>A passable cliff or quarry. Minimum height: 1 m.
 If the direction of fall of the cliff is not apparent from the contours, or to improve legibility, short tags may be drawn in the direction of the downslope.
 For non-vertical cliffs, the tags should be drawn to show the full horizontal extent. Ends of the top line may be rounded or square. A passage between two cliffs must be at least 0.2 mm. A cliff should interplay with the contour lines.
@@ -967,53 +955,7 @@ Crossing a cliff will normally slow progress.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="30" code="202.1" name="Cliff, no tags">
-                <description>Should be used if the direction of fall of the rock face is apparent from the contours and the legibility is good.</description>
-                <line_symbol color="2" line_width="200" minimum_length="600" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-            </symbol>
-            <symbol type="1" id="31" code="202.1.1" name="Cliff, no tags, minimum size">
-                <description>Should be used if the direction of fall of the rock face is apparent from the contours and the legibility is good.</description>
-                <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="2" line_width="200" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="2">
-                                <coord x="-300" y="0"/>
-                                <coord x="300" y="0"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                </point_symbol>
-            </symbol>
-            <symbol type="2" id="32" code="202.2" name="Cliff, no tags, rounded">
-                <description>For passable rock faces shown without tags the ends of the line may be rounded to improve legibility.</description>
-                <line_symbol color="2" line_width="200" minimum_length="600" join_style="2" cap_style="1" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-            </symbol>
-            <symbol type="1" id="33" code="202.2.1" name="Cliff, no tags, rounded, minimum size">
-                <description>For passable rock faces shown without tags the ends of the line may be rounded to improve legibility.</description>
-                <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
-                    <element>
-                        <symbol type="2" code="">
-                            <line_symbol color="2" line_width="200" minimum_length="0" join_style="1" cap_style="1" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-                        </symbol>
-                        <object type="1">
-                            <coords count="2">
-                                <coord x="-230" y="0"/>
-                                <coord x="230" y="0"/>
-                            </coords>
-                            <pattern rotation="0">
-                                <coord x="0" y="0"/>
-                            </pattern>
-                        </object>
-                    </element>
-                </point_symbol>
-            </symbol>
-            <symbol type="1" id="34" code="203" name="Rocky pit or cave">
+            <symbol type="1" id="30" code="203" name="Rocky pit or cave">
                 <description>Rocky pits, holes, caves or mineshafts which may constitute a danger to the competitor. Minimum depth: 1 m.
 Location is the centre of gravity of the symbol, and the symbol shall be orientated to north, except for caves with a distinct entrance, where the symbol should point into the cave.
 Rocky pits larger than 5 m in diameter should be exaggerated and represented using
@@ -1041,29 +983,25 @@ cliff symbols (201, 202).
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="35" code="204" name="Boulder">
+            <symbol type="1" id="31" code="204" name="Boulder">
                 <description>A distinct boulder (should be higher than 1 m), which is immediately identifiable on the ground. Groups of boulders are represented using symbol 207 (boulder cluster) or a boulder field symbol (208, 209).
 To be able to show the distinction between neighbouring (closer than 30 metres apart) boulders with significant difference in size, it is permitted to enlarge the symbol to 0.5 mm for some of the boulders.</description>
                 <point_symbol inner_radius="200" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="1" id="36" code="204.1" name="Boulder, enlarged">
+            <symbol type="1" id="32" code="204.1" name="Boulder, enlarged">
                 <description>To be able to show the distinction between boulders with significant difference in size it is permitted to enlarge this symbol by 20% (diameter 0.5 mm).</description>
                 <point_symbol inner_radius="250" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="1" id="37" code="205" name="Large boulder">
+            <symbol type="1" id="33" code="205" name="Large boulder">
                 <description>A particularly large and distinct boulder. A large boulder should be more than 2 m high. To be able to show the distinction between neighbouring (closer than 30 metres apart) large boulders with significant difference in size, it is permitted to reduce the size of the symbol to 0.5 mm for some of the boulders.</description>
                 <point_symbol inner_radius="300" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="1" id="38" code="205.1" name="Large boulder, reduced">
-                <description>To be able to show the distinction between neighbouring (closer than 30 metres apart) large boulders with significant difference in size, it is permitted to reduce the size of the symbol to 0.5 mm for some of the boulders.</description>
-                <point_symbol inner_radius="250" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
-            </symbol>
-            <symbol type="4" id="39" code="206" name="Gigantic boulder">
+            <symbol type="4" id="34" code="206" name="Gigantic boulder">
                 <description>A rock pillar or gigantic boulder that is so high and steep that it is impossible topass/climb.
 The gap between gigantic boulders or between gigantic boulders and other impassable feature symbols must exceed 0.3 mm on the map.</description>
                 <area_symbol inner_color="2" min_area="0" patterns="0"/>
             </symbol>
-            <symbol type="1" id="40" code="207" name="Boulder cluster">
+            <symbol type="1" id="35" code="207" name="Boulder cluster">
                 <description>A distinct group of boulders so closely clustered together that they cannot be marked individually. The boulders in the cluster should be higher than 1 metre. A boulder cluster must be easily identifiable as a group of boulders.
 To be able to show the distinction between neighbouring (maximum 30 metres apart), boulder clusters with significant difference in boulder size, it is permitted to enlarge this symbol by 20% (edge length 0.96 mm) for some of the boulder clusters.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -1085,7 +1023,7 @@ To be able to show the distinction between neighbouring (maximum 30 metres apart
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="41" code="207.1" name="Boulder cluster, large">
+            <symbol type="1" id="36" code="207.1" name="Boulder cluster, large">
                 <description>To be able to show the distinction between neighbouring (maximum 30 metres apart), boulder clusters with significant difference in boulder size, it is permitted to enlarge this symbol by 20% (edge length 0.96 mm) for some of the boulder clusters.</description>
                 <point_symbol inner_radius="1250" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -1106,12 +1044,12 @@ To be able to show the distinction between neighbouring (maximum 30 metres apart
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="4" id="42" code="208" name="Boulder field">
+            <symbol type="4" id="37" code="208" name="Boulder field">
                 <description>An area which is covered with so many scattered blocks of stone that they cannot be marked individually, is shown with randomly placed and orientated solid triangles. A boulder field will generally not impact runnability. If the runnability of the boulder field is reduced, symbol 209 (dense boulder field) should be used or the symbol should be combined with a stony ground symbol.
 A minimum of two triangles should be used. One triangle may be used if it is combined with other rock symbols (for instance directly below cliff symbols (201, 202), adjacent to boulder symbols (204-206) or combined with stony ground symbols (210-212)).
 To be able to show obvious height differences within a boulder field, it is permitted to enlarge some of the triangles to 120%.</description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="3330" line_offset="0" offset_along_line="0" point_distance="3000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="3330" line_offset="0" offset_along_line="0" point_distance="3000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="9">
                                 <element>
@@ -1254,7 +1192,7 @@ To be able to show obvious height differences within a boulder field, it is perm
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="43" code="208.1" name="Boulder field, single triangle">
+            <symbol type="1" id="38" code="208.1" name="Boulder field, single triangle">
                 <description>An area which is covered with so many blocks of stone that they cannot be marked individually is shown with randomly orientated solid triangles with sides of ratio 8:6:5. A minimum of two triangles should be used. The going is indicated by the density of the triangles. To be able to show the distinction between boulder fields with a significant difference in boulder size it is permitted to enlarge the triangles by 20%.</description>
                 <point_symbol rotatable="true" inner_radius="640" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -1275,7 +1213,7 @@ To be able to show obvious height differences within a boulder field, it is perm
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="44" code="208.2" name="Boulder field, single triangle, enlarged">
+            <symbol type="1" id="39" code="208.2" name="Boulder field, single triangle, enlarged">
                 <description>To be able to show the distinction between boulder fields with a significant difference in boulder size it is permitted to enlarge the triangles by 20%.</description>
                 <point_symbol rotatable="true" inner_radius="768" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -1296,12 +1234,12 @@ To be able to show obvious height differences within a boulder field, it is perm
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="4" id="45" code="209" name="Dense boulder field">
+            <symbol type="4" id="40" code="209" name="Dense boulder field">
                 <description>An area which is covered with so many blocks of stone that they cannot be marked individually and the runnability is affected, is shown with randomly placed and orientated solid triangles. A minimum of two triangles must be used.
 Density: 2–3 symbols / mm2 (31%-47%). To be able to show obvious height differences within a boulder field, it is permitted to enlarge some of the triangles to 120%.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="2000" line_offset="0" offset_along_line="0" point_distance="2000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="2000" line_offset="0" offset_along_line="0" point_distance="2000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="10">
                                 <element>
@@ -1459,13 +1397,13 @@ Density: 2–3 symbols / mm2 (31%-47%). To be able to show obvious height differ
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="46" code="210" name="Stony ground, slow running">
+            <symbol type="4" id="41" code="210" name="Stony ground, slow running">
                 <description>Stony or rocky ground which reduces runnability to about 60-80% of normal speed.
 The dots should be randomly distributed but not interfere with the representation of important terrain features and objects.
 The minimum number of dots is three (footprint 10 m x 10 m).
 To avoid confusion with symbol 416 (distinct vegetation boundary), the dots should not be arranged to form a line.</description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="2000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="2000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="7">
                                 <element>
@@ -1543,21 +1481,21 @@ To avoid confusion with symbol 416 (distinct vegetation boundary), the dots shou
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="47" code="210.1" name="Stony ground, individual dot">
+            <symbol type="1" id="42" code="210.1" name="Stony ground, individual dot">
                 <description>Stony or rocky ground which reduces runnability to about 60-80% of normal speed.
 The dots should be randomly distributed but not interfere with the representation of important terrain features and objects.
 The minimum number of dots is three (footprint 10 m x 10 m).
 To avoid confusion with symbol 416 (distinct vegetation boundary), the dots should not be arranged to form a line.</description>
                 <point_symbol inner_radius="100" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="4" id="48" code="211" name="Stony ground, walk">
+            <symbol type="4" id="43" code="211" name="Stony ground, walk">
                 <description>Stony or rocky ground which reduces the runnability significantly (to about 20-60% of normal speed).
 The dots should be randomly distributed but not interfere with the representation of important terrain features and objects.
 The minimum number of dots is three (footprint 8 m x 8 m).
 To avoid confusion with symbol 416 (distinct vegetation boundary), the dots should not be arranged to form a line.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="7">
                                 <element>
@@ -1635,14 +1573,14 @@ To avoid confusion with symbol 416 (distinct vegetation boundary), the dots shou
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="49" code="212" name="Stony ground, fight">
+            <symbol type="4" id="44" code="212" name="Stony ground, fight">
                 <description>Stony or rocky ground which is hardly passable (less than 20% of normal speed).
 The dots should be randomly distributed but not interfere with the representation of important terrain features and objects.
 The minimum number of dots is three (footprint 7 m x 7 m).
 To avoid confusion with symbol 416 (distinct vegetation boundary), the dots should not be arranged to form a line.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
-                    <pattern type="2" angle="0" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
+                    <pattern type="2" angle="0" no_clipping="2" rotatable="true" line_spacing="1000" line_offset="0" offset_along_line="0" point_distance="1000">
                         <symbol type="1" code="" name="Pattern fill 1">
                             <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="12">
                                 <element>
@@ -1770,7 +1708,7 @@ To avoid confusion with symbol 416 (distinct vegetation boundary), the dots shou
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="50" code="213" name="Open sandy ground">
+            <symbol type="4" id="45" code="213" name="Open sandy ground">
                 <description>An area of soft sandy ground where runnability is reduced to less than 80% of normal speed.</description>
                 <area_symbol inner_color="26" min_area="1000" patterns="1">
                     <pattern type="2" angle="0.785398" line_spacing="450" line_offset="0" offset_along_line="0" point_distance="450">
@@ -1780,61 +1718,61 @@ To avoid confusion with symbol 416 (distinct vegetation boundary), the dots shou
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="51" code="214" name="Bare rock">
+            <symbol type="4" id="46" code="214" name="Bare rock">
                 <description>A runnable area of rock without earth or vegetation should be shown as bare rock.
 An area of rock covered with grass, moss or other low vegetation, shall not be shown using the bare rock symbol.
 An area of less runnable bare rock should be shown using a stony ground symbol (210-212).</description>
                 <area_symbol inner_color="7" min_area="500" patterns="0"/>
             </symbol>
-            <symbol type="2" id="52" code="215" name="Trench">
+            <symbol type="2" id="47" code="215" name="Trench">
                 <description>Rocky or artificial trench. Minimum depth should be 1 m.
 Minimum length: 2 mm (footprint 30 m).
 Shorter trenches may be exaggerated to the minimum graphical dimension.
 Impassable trenches shall be represented using symbol 201 (impassable cliff).
 Collapsed and easily crossable trenches should be mapped as erosion gullies.</description>
-                <line_symbol color="13" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="0" end_length="0" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="0" mid_symbol_distance="0">
+                <line_symbol color="-1" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="0" end_length="0" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="0" mid_symbol_distance="0">
                     <borders>
                         <border color="2" width="100" shift="50" dash_length="2000" break_length="1000"/>
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="16" id="53" code="301" name="Uncrossable body of water, with bank line">
+            <symbol type="16" id="48" code="301" name="Uncrossable body of water, with bank line">
                 <description>The black bank line emphasises that the feature is uncrossable. Dominant areas of water may be shown with 70% colour. Small areas of water and bodies of water that have narrow parts shall always be shown with full colour.</description>
                 <combined_symbol parts="2">
-                    <part symbol="54"/>
-                    <part symbol="55"/>
+                    <part symbol="49"/>
+                    <part symbol="50"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="54" code="301.1" name="Uncrossable body of water">
+            <symbol type="4" id="49" code="301.1" name="Uncrossable body of water">
                 <description>The black bank line emphasises that the feature is uncrossable. Dominant areas of water may be shown with 70% colour. Small areas of water and bodies of water that have narrow parts shall always be shown with full colour.</description>
                 <area_symbol inner_color="10" min_area="1000" patterns="0"/>
             </symbol>
-            <symbol type="2" id="55" code="301.2" name="Uncrossable body of water, bank line">
+            <symbol type="2" id="50" code="301.2" name="Uncrossable body of water, bank line">
                 <description>A black bank line indicates that the feature cannot be crossed.</description>
                 <line_symbol color="2" line_width="180" minimum_length="0" join_style="0" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="16" id="56" code="302" name="Shallow body of water, with outline">
+            <symbol type="16" id="51" code="302" name="Shallow body of water, with outline">
                 <description>A shallow seasonal or periodic body of water may be represented using a dashed outline. Small shallow water bodies may be represented as 100% blue (without an outline).
 </description>
                 <combined_symbol parts="2">
-                    <part symbol="58"/>
-                    <part symbol="57"/>
+                    <part symbol="53"/>
+                    <part symbol="52"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="57" code="302.1" name="Shallow body of water">
+            <symbol type="4" id="52" code="302.1" name="Shallow body of water">
                 <description>A shallow seasonal or periodic body of water may be represented using a dashed outline. Small shallow water bodies may be represented as 100% blue (without an outline).</description>
                 <area_symbol inner_color="11" min_area="500" patterns="0"/>
             </symbol>
-            <symbol type="2" id="58" code="302.2" name="Shallow body of water, solid outline">
+            <symbol type="2" id="53" code="302.2" name="Shallow body of water, solid outline">
                 <description>Use this symbol to represent regular outline for shallow body of water.</description>
                 <line_symbol color="10" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1250" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="59" code="302.3" name="Shallow body of water, dashed outline">
+            <symbol type="2" id="54" code="302.3" name="Shallow body of water, dashed outline">
                 <description>A shallow seasonal or periodic body of water may be represented using a dashed
 0.10 outline.</description>
                 <line_symbol color="10" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1250" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="1" id="60" code="303" name="Waterhole">
+            <symbol type="1" id="55" code="303" name="Waterhole">
                 <description>A water-filled pit or an area of water which is too small to be shown to scale. Location is the centre of gravity of the symbol, and the symbol is orientated to north.</description>
                 <point_symbol inner_radius="900" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -1858,37 +1796,37 @@ Collapsed and easily crossable trenches should be mapped as erosion gullies.</de
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="61" code="304" name="Crossable watercourse">
+            <symbol type="2" id="56" code="304" name="Crossable watercourse">
                 <description>A crossable watercourse, minimum 2 m wide. The width of watercourses over 5 m wide should be shown to scale.</description>
                 <line_symbol color="10" line_width="300" minimum_length="1000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="62" code="305" name="Small crossable watercourse">
+            <symbol type="2" id="57" code="305" name="Small crossable watercourse">
                 <description>A crossable watercourse (including a major drainage ditch) less than 2 m wide.</description>
                 <line_symbol color="10" line_width="180" minimum_length="1000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="63" code="306" name="Minor/seasonal water channel">
+            <symbol type="2" id="58" code="306" name="Minor/seasonal water channel">
                 <description>A natural or man-made minor water channel which may contain water only intermittently.</description>
                 <line_symbol color="10" line_width="180" minimum_length="2750" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1250" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="16" id="64" code="307" name="Uncrossable marsh, with border line">
+            <symbol type="16" id="59" code="307" name="Uncrossable marsh, with border line">
                 <description>A marsh which is uncrossable or dangerous for the competitor. The black outline emphasises that the feature is uncrossable. The black outline is omitted for boundaries between uncrossable marsh and symbol 301 (uncrossable body of water). The symbol may be combined with a rough open land symbol (403, 404) to show openness. The symbol is orientated to north.</description>
                 <combined_symbol parts="2">
-                    <part symbol="65"/>
-                    <part symbol="66"/>
+                    <part symbol="60"/>
+                    <part symbol="61"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="65" code="307.1" name="Uncrossable marsh">
+            <symbol type="4" id="60" code="307.1" name="Uncrossable marsh">
                 <description>A marsh which is uncrossable or dangerous for the competitor. The black outline emphasises that the feature is uncrossable. The black outline is omitted for boundaries between uncrossable marsh and symbol 301 (uncrossable body of water). The symbol may be combined with a rough open land symbol (403, 404) to show openness. The symbol is orientated to north.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
                     <pattern type="1" angle="0" line_spacing="500" line_offset="0" offset_along_line="0" color="10" line_width="250"/>
                 </area_symbol>
             </symbol>
-            <symbol type="2" id="66" code="307.2" name="Uncrossable marsh, border line">
+            <symbol type="2" id="61" code="307.2" name="Uncrossable marsh, border line">
                 <description>A black line surrounds the symbol 307.</description>
                 <line_symbol color="2" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="67" code="308" name="Marsh">
+            <symbol type="4" id="62" code="308" name="Marsh">
                 <description>A crossable marsh, usually with a distinct edge.
 The symbol shall be combined with other symbols to show runnability and openness.
 The symbol is orientated to north.</description>
@@ -1896,7 +1834,7 @@ The symbol is orientated to north.</description>
                     <pattern type="1" angle="0" line_spacing="300" line_offset="0" offset_along_line="0" color="10" line_width="100"/>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="68" code="308.1" name="Marsh, minimum size">
+            <symbol type="1" id="63" code="308.1" name="Marsh, minimum size">
                 <description>A crossable marsh, usually with a distinct edge.
 The symbol shall be combined with other symbols to show runnability and openness.
 The symbol is orientated to north.</description>
@@ -1931,7 +1869,7 @@ The symbol is orientated to north.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="69" code="309" name="Narrow marsh">
+            <symbol type="2" id="64" code="309" name="Narrow marsh">
                 <description>A marsh or trickle of water which is too narrow (less than about 5 m wide) to be shown with the marsh symbol.</description>
                 <line_symbol color="-1" line_width="0" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="450" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="2" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -1941,7 +1879,7 @@ The symbol is orientated to north.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="4" id="70" code="310" name="Indistinct marsh">
+            <symbol type="4" id="65" code="310" name="Indistinct marsh">
                 <description>An indistinct marsh, seasonal marsh or an area of gradual transition from marsh to firm ground, which is crossable. The edge is generally indistinct and the vegetation similar to that of the surrounding ground.
 The symbol shall be combined with other symbols to show runnability and openness.
 The symbol is orientated to north.</description>
@@ -1988,7 +1926,7 @@ The symbol is orientated to north.</description>
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="71" code="310.1" name="Indistinct marsh, minimum size">
+            <symbol type="1" id="66" code="310.1" name="Indistinct marsh, minimum size">
                 <description>An indistinct marsh, seasonal marsh or an area of gradual transition from marsh to firm ground, which is crossable. The edge is generally indistinct and the vegetation similar to that of the surrounding ground.
 The symbol shall be combined with other symbols to show runnability and openness.
 The symbol is orientated to north.</description>
@@ -2051,7 +1989,7 @@ The symbol is orientated to north.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="72" code="311" name="Well, fountain or water tank">
+            <symbol type="1" id="67" code="311" name="Well, fountain or water tank">
                 <description>A prominent well, fountain, water tank or captive spring.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -2073,7 +2011,7 @@ The symbol is orientated to north.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="73" code="312" name="Spring">
+            <symbol type="1" id="68" code="312" name="Spring">
                 <description>A source of water.
 Location is the centre of gravity of the symbol, and the symbol is orientated to open downstream.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -2098,7 +2036,7 @@ Location is the centre of gravity of the symbol, and the symbol is orientated to
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="74" code="313" name="Prominent water feature">
+            <symbol type="1" id="69" code="313" name="Prominent water feature">
                 <description>Prominent water feature
 The symbol is orientated to north.</description>
                 <point_symbol inner_radius="1048" inner_color="-1" outer_width="0" outer_color="-1" elements="5">
@@ -2174,13 +2112,13 @@ The symbol is orientated to north.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="4" id="75" code="401" name="Open land">
+            <symbol type="4" id="70" code="401" name="Open land">
                 <description>Open land that has a ground cover (grass, moss or similar) which offers better runnability than typical open forest. If yellow coloured areas become dominant, a screen (75% instead of full yellow) may be used.
 May not be combined with other area symbols than symbol 113 (broken ground), symbol 208 (boulder field) and marsh symbols (308, 310).
 </description>
                 <area_symbol inner_color="25" min_area="500" patterns="0"/>
             </symbol>
-            <symbol type="4" id="76" code="402" name="Open land with scattered trees">
+            <symbol type="4" id="71" code="402" name="Open land with scattered trees">
                 <description>Areas with scattered trees or bushes in open land may be generalised by using a regular pattern of large dots in the yellow screen. The dots may be white (scattered trees) or green (scattered bushes/thickets). Prominent individual trees may be added using symbol 417 (prominent large tree). If yellow coloured areas become dominant, a screen (75% instead of full yellow) may be used.
 May not be combined with other area symbols than symbol 113 (broken ground), symbol 208 (boulder field) or marsh symbols (308, 310).
 </description>
@@ -2192,7 +2130,7 @@ May not be combined with other area symbols than symbol 113 (broken ground), sym
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="77" code="402.1" name="Open land with scattered bushes">
+            <symbol type="4" id="72" code="402.1" name="Open land with scattered bushes">
                 <description>Areas with scattered trees or bushes in open land may be generalised by using a regular pattern of large dots in the yellow screen. The dots may be white (scattered trees) or green (scattered bushes/thickets). Prominent individual trees may be added using symbol 417 (prominent large tree). If yellow coloured areas become dominant, a screen (75% instead of full yellow) may be used.
 May not be combined with other area symbols than symbol 113 (broken ground), symbol 208 (boulder field) or marsh symbols (308, 310).</description>
                 <area_symbol inner_color="25" min_area="4000" patterns="1">
@@ -2203,13 +2141,13 @@ May not be combined with other area symbols than symbol 113 (broken ground), sym
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="78" code="403" name="Rough open land">
+            <symbol type="4" id="73" code="403" name="Rough open land">
                 <description>Heath, moorland, felled areas, newly planted areas (trees lower than ca. 1 m) or other generally open land with rough ground vegetation, heather or tall grass offering the same runnability as typical open forest.
 May be combined with symbol 407 (vegetation, slow running, good visibility) or 409 (vegetation, walk, good visibility) to show reduced runnability.
 Minimum area: 1 mm x 1 mm (footprint 15 m x 15 m). Smaller areas must either be left out, exaggerated or shown using symbol 401 (open land).</description>
                 <area_symbol inner_color="26" min_area="1000" patterns="0"/>
             </symbol>
-            <symbol type="4" id="79" code="404" name="Rough open land with scattered trees">
+            <symbol type="4" id="74" code="404" name="Rough open land with scattered trees">
                 <description>Areas with scattered trees or bushes in rough open land may be generalised by using a regular pattern of large dots in the yellow screen.
 The dots may be white (scattered trees) or green (scattered bushes/thickets). Only the white dot variant can be combined with symbol 407 (vegetation, slow
 running, good visibility) or 409 (vegetation, walk, good visibility) to show reduced runnability.
@@ -2225,7 +2163,7 @@ open land).
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="80" code="404.1" name="Rough open land with scattered bushes">
+            <symbol type="4" id="75" code="404.1" name="Rough open land with scattered bushes">
                 <description>Areas with scattered trees or bushes in rough open land may be generalised by using a regular pattern of large dots in the yellow screen.
 The dots may be white (scattered trees) or green (scattered bushes/thickets). Only the white dot variant can be combined with symbol 407 (vegetation, slow
 running, good visibility) or 409 (vegetation, walk, good visibility) to show reduced runnability.
@@ -2241,90 +2179,84 @@ open land).
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="81" code="405" name="Forest">
+            <symbol type="4" id="76" code="405" name="Forest">
                 <description>Typical open forest for the particular type of terrain. If no part of the forest is easily runnable then no white should appear on the map.
 </description>
                 <area_symbol inner_color="13" min_area="500" patterns="0"/>
             </symbol>
-            <symbol type="4" id="82" code="406" name="Vegetation, slow running">
+            <symbol type="4" id="77" code="406" name="Vegetation, slow running">
                 <description>An area with dense vegetation (low visibility) which reduces running to about 60-80% of normal speed.</description>
                 <area_symbol inner_color="21" min_area="1000" patterns="0"/>
             </symbol>
-            <symbol type="4" id="83" code="406.1" name="Vegetation runnable in one direction, 1">
+            <symbol type="4" id="78" code="406.1" name="Vegetation runnable in one direction, 1">
                 <description>When an area of forest provides good running in one direction but less good in others, white stripes are left in the screen symbol to show the direction of good running.</description>
                 <area_symbol inner_color="21" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="1500" line_offset="0" offset_along_line="0" color="13" line_width="400"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="84" code="407" name="Vegetation, slow running, good visibility&#10;">
+            <symbol type="4" id="79" code="407" name="Vegetation, slow running, good visibility&#10;">
                 <description>An area of dense undergrowth but otherwise good visibility (brambles, heather, low bushes, and including cut branches) which reduces running to ca. 60-80% of normal speed. This symbol may not be combined with 406 or 408.</description>
                 <area_symbol inner_color="-1" min_area="1500" patterns="1">
                     <pattern type="1" angle="1.5708" line_spacing="840" line_offset="0" offset_along_line="0" color="22" line_width="120"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="85" code="408" name="Vegetation, walk&#10;">
+            <symbol type="4" id="80" code="408" name="Vegetation, walk&#10;">
                 <description>An area with dense trees or thickets (low visibility) which reduce running to about 20-60% of normal speed.
 </description>
                 <area_symbol inner_color="20" min_area="500" patterns="0"/>
             </symbol>
-            <symbol type="4" id="86" code="408.1" name="Vegetation runnable in one direction, 2">
+            <symbol type="4" id="81" code="408.1" name="Vegetation runnable in one direction, 2">
                 <description>When an area of forest provides good running in one direction but less good in others, white stripes are left in the screen symbol to show the direction of good running.</description>
                 <area_symbol inner_color="20" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="1500" line_offset="0" offset_along_line="0" color="13" line_width="400"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="87" code="408.2" name="Vegetation runnable in one direction, 2, 20%">
+            <symbol type="4" id="82" code="408.2" name="Vegetation runnable in one direction, 2, 20%">
                 <description>When an area of forest provides good running in one direction but less good in others, light green stripes are left in the screen symbol to show the direction of good running.</description>
                 <area_symbol inner_color="21" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="1500" line_offset="750" offset_along_line="0" color="20" line_width="1100"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="88" code="409" name="Vegetation, walk, good visibility">
+            <symbol type="4" id="83" code="409" name="Vegetation, walk, good visibility">
                 <description>An area of good visibility that is difficult to run through due to for instance undergrowth (brambles, heather, low bushes, cut branches). Running speed is reduced to about 20-60% of normal speed.
 Areas of good visibility that are very difficult to run or impassable are represented using symbol 410 (vegetation, fight) or 411 (vegetation, impassable).</description>
                 <area_symbol inner_color="-1" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" line_spacing="420" line_offset="0" offset_along_line="0" color="22" line_width="140"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="89" code="410" name="Vegetation, fight">
+            <symbol type="4" id="84" code="410" name="Vegetation, fight">
                 <description>An area of dense vegetation (trees or undergrowth) which is barely passable. Running reduced to ca. 0-20% of normal speed.
 For fairness reasons, areas that are really difficult to get through (10% and slower) shall be represented using symbol 411 (vegetation, impassable).</description>
                 <area_symbol inner_color="19" min_area="300" patterns="0"/>
             </symbol>
-            <symbol type="2" id="90" code="410.0.1" name="Vegetation, fight, minimum width">
-                <description>An area of dense vegetation (trees or undergrowth) which is barely passable. Running reduced to ca. 0-20% of normal speed.
-For fairness reasons, areas that are really difficult to get through (10% and slower) shall be represented using symbol 411 (vegetation, impassable).
-Minimum width: 0.25 mm.</description>
-                <line_symbol color="14" line_width="250" minimum_length="550" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
-            </symbol>
-            <symbol type="4" id="91" code="410.1" name="Forest runnable in one direction, 3">
+            <symbol type="4" id="85" code="410.1" name="Forest runnable in one direction, 3">
                 <description>When an area of forest provides good running in one direction but less good in others, white stripes are left in the screen symbol to show the direction of good running.</description>
                 <area_symbol inner_color="19" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="1500" line_offset="0" offset_along_line="0" color="13" line_width="400"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="92" code="410.2" name="Forest runnable in one direction, 3, 20%">
+            <symbol type="4" id="86" code="410.2" name="Forest runnable in one direction, 3, 20%">
                 <description>When an area of forest provides good running in one direction but less good in others, light green stripes are left in the screen symbol to show the direction of good running.</description>
                 <area_symbol inner_color="21" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="1500" line_offset="750" offset_along_line="0" color="19" line_width="1100"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="93" code="410.3" name="Forest runnable in one direction, 3, 50%">
+            <symbol type="4" id="87" code="410.3" name="Forest runnable in one direction, 3, 50%">
                 <description>When an area of forest provides good running in one direction but less good in others, light green stripes are left in the screen symbol to show the direction of good running.</description>
                 <area_symbol inner_color="20" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="1500" line_offset="750" offset_along_line="0" color="19" line_width="1100"/>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="94" code="411" name="Vegetation, impassable">
+            <symbol type="4" id="88" code="411" name="Vegetation, impassable">
                 <description>An area of dense vegetation (trees or undergrowth) which is effectively impassable. Most useful for narrow and small areas.</description>
                 <area_symbol inner_color="18" min_area="600" patterns="0"/>
             </symbol>
-            <symbol type="2" id="95" code="411.0.1" name="Vegetation, impassable, minimum width">
+            <symbol type="2" id="89" code="411.0.1" name="Vegetation, impassable, minimum width">
                 <description>An area of dense vegetation (trees or undergrowth) which is effectively impassable.
 Minimum width: 0.35 mm</description>
                 <line_symbol color="18" line_width="350" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="96" code="411.1" name="Vegetation, impassable">
+            <symbol type="4" id="90" code="411.1" name="Vegetation, impassable">
                 <description>An area of dense vegetation (trees or undergrowth) which is effectively impassable. Most useful for narrow and small areas.</description>
                 <area_symbol inner_color="19" min_area="600" patterns="1">
                     <pattern type="2" angle="0" line_spacing="200" line_offset="0" offset_along_line="0" point_distance="200">
@@ -2334,7 +2266,7 @@ Minimum width: 0.35 mm</description>
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="97" code="412" name="Cultivated land">
+            <symbol type="4" id="91" code="412" name="Cultivated land">
                 <description>Cultivated land, normally used for growing crops. Runnability may vary according to the type of crops grown and the time of year. For agroforestry, symbol 405 (forest) or 402 (open land with scattered trees) may be used instead of yellow.
 Since the runnability may vary, such areas should be avoided when setting courses.
 The symbol is combined with symbol 709 (out of bounds area) to show cultivated land that shall not be entered.
@@ -2347,7 +2279,7 @@ The symbol is combined with symbol 709 (out of bounds area) to show cultivated l
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="98" code="413" name="Orchard">
+            <symbol type="4" id="92" code="413" name="Orchard">
                 <description>Land planted with trees or bushes, normally in a regular pattern.
 The dot lines may be orientated to show the direction of planting.
 Must be combined with either symbol 401 (open land) or 403 (rough open land).
@@ -2360,7 +2292,7 @@ May be combined with symbol 407 (vegetation, slow running, good visibility) or 4
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="99" code="413.1" name="Orchard, rough open">
+            <symbol type="4" id="93" code="413.1" name="Orchard, rough open">
                 <description>Land planted with trees or bushes, normally in a regular pattern.
 The dot lines may be orientated to show the direction of planting.
 Must be combined with either symbol 401 (open land) or 403 (rough open land).
@@ -2373,7 +2305,7 @@ May be combined with symbol 407 (vegetation, slow running, good visibility) or 4
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="100" code="414" name="Vineyard">
+            <symbol type="4" id="94" code="414" name="Vineyard">
                 <description>A vineyard or similar cultivated land containing dense rows of plants offering good or normal runnability in the direction of planting. The lines shall be orientated to show the direction of planting. Must be combined with either symbol 401 (open land) or symbol 403 (rough open land).</description>
                 <area_symbol inner_color="25" min_area="4000" patterns="2">
                     <pattern type="2" angle="1.5708" rotatable="true" line_spacing="1700" line_offset="0" offset_along_line="0" point_distance="1900">
@@ -2418,7 +2350,7 @@ May be combined with symbol 407 (vegetation, slow running, good visibility) or 4
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="4" id="101" code="414.1" name="Vineyard, rough open">
+            <symbol type="4" id="95" code="414.1" name="Vineyard, rough open">
                 <description>A vineyard or similar cultivated land containing dense rows of plants offering good or normal runnability in the direction of planting. The lines shall be orientated to show the direction of planting. Must be combined with either symbol 401 (open land) or symbol 403 (rough open land).</description>
                 <area_symbol inner_color="26" min_area="500" patterns="2">
                     <pattern type="2" angle="1.5708" rotatable="true" line_spacing="1700" line_offset="0" offset_along_line="0" point_distance="1900">
@@ -2463,11 +2395,11 @@ May be combined with symbol 407 (vegetation, slow running, good visibility) or 4
                     </pattern>
                 </area_symbol>
             </symbol>
-            <symbol type="2" id="102" code="415" name="Distinct cultivation boundary">
+            <symbol type="2" id="96" code="415" name="Distinct cultivation boundary">
                 <description>A boundary of symbol 412 (cultivated land) or a boundary between areas of cultivated land when not shown with other symbols (fence, wall, path, etc.).</description>
                 <line_symbol color="2" line_width="100" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="103" code="416" name="Distinct vegetation boundary">
+            <symbol type="2" id="97" code="416" name="Distinct vegetation boundary">
                 <description>A distinct forest edge or vegetation boundary within the forest.
 Very distinct forest edges and vegetation boundaries may be represented using the cultivation boundary symbol. Only one of the vegetation boundary symbols (black dotted line or dashed green line) can be used on a map.
 Minimum length, black dot implementation: 5 dots (2.5 mm – footprint 37 m).
@@ -2480,21 +2412,21 @@ Minimum length, black dot implementation: 5 dots (2.5 mm – footprint 37 m).
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="104" code="416.1" name="Distinct vegetation boundary, green dashed line">
+            <symbol type="2" id="98" code="416.1" name="Distinct vegetation boundary, green dashed line">
                 <description>For areas with a lot of rock features, it is recommended to use the green dashed line for vegetation boundaries.
 A disadvantage with a green line is that it cannot be used to show distinct vegetation boundaries around and within symbols 410 (vegetation, fight) and 411 (vegetation, impassable). An alternative for these situations is to use symbol 415 (distinct cultivation boundary).
 Minimum length, green line implementation: 4 dashes (1.8 mm – footprint 27 m).</description>
                 <line_symbol color="18" line_width="120" minimum_length="1800" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="300" break_length="200" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="1" id="105" code="417" name="Prominent large tree">
+            <symbol type="1" id="99" code="417" name="Prominent large tree">
                 <point_symbol inner_radius="270" inner_color="-1" outer_width="180" outer_color="14" elements="0"/>
             </symbol>
-            <symbol type="1" id="106" code="418" name="Prominent bush or tree">
+            <symbol type="1" id="100" code="418" name="Prominent bush or tree">
                 <description>Use sparingly, as it is easily mistaken for symbol 109 (small knoll) by the colour vision
 impaired.</description>
                 <point_symbol inner_radius="250" inner_color="14" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="1" id="107" code="419" name="Prominent vegetation feature">
+            <symbol type="1" id="101" code="419" name="Prominent vegetation feature">
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
                     <element>
                         <symbol type="2" code="">
@@ -2526,10 +2458,10 @@ impaired.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="16" id="108" code="501" name="Paved area, with bounding line">
+            <symbol type="16" id="102" code="501" name="Paved area, with bounding line">
                 <description>An area with a firm level surface such as asphalt, hard gravel, tiles, concrete or the like. Paved areas should be bordered (or framed) by a thin black line where they have a distinct boundary.</description>
                 <combined_symbol parts="2">
-                    <part symbol="109"/>
+                    <part symbol="103"/>
                     <part private="true">
                         <symbol type="2" code="501.0.1" name="Paved area, bounding line">
                             <description>Paved areas should be bordered (or framed) by a thin black line where they have a distinct boundary.</description>
@@ -2538,34 +2470,28 @@ impaired.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="109" code="501.1" name="Paved area">
+            <symbol type="4" id="103" code="501.1" name="Paved area">
                 <description>An area with a firm level surface such as asphalt, hard gravel, tiles, concrete or the like.</description>
                 <area_symbol inner_color="3" min_area="500" patterns="0"/>
             </symbol>
-            <symbol type="2" id="110" code="501.2" name="Paved area, bounding line">
+            <symbol type="2" id="104" code="501.2" name="Paved area, bounding line">
                 <description>Paved areas should be bordered (or framed) by a thin black line where they have a distinct boundary.</description>
                 <line_symbol color="2" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="111" code="502" name="Wide road, minimum width">
-                <description>Road wider than 5 m.
-The width should be drawn to scale, but not smaller than the minimum width. The outer boundary lines may be replaced with other black line symbols, such as symbol 516 (fence), 518 (impassable fence), 513 (wall) or 515 (impassable wall) if the feature is so close to the road edge that it cannot practically be shown as a separate symbol.
-</description>
+            <symbol type="2" id="105" code="502" name="Wide road, minimum width">
+                <description>The width should be drawn to scale, but not smaller than the minimum width (0.3 +
+2*0.14 mm – footprint 8.7 m)
+The outer boundary lines may be replaced with other black line symbols, such as
+symbol 516 (fence), 518 (impassable fence), 513 (wall) or 515 (impassable wall) if the
+feature is so close to the road edge that it cannot practically be shown as a separate
+symbol.</description>
                 <line_symbol color="3" line_width="300" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <borders>
                         <border color="4" width="140" shift="70" dash_length="2000" break_length="1000"/>
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="112" code="502.1" name="Wide road">
-                <description>Road about 10 m width.
-The width should be drawn to scale, but not smaller than the minimum width. The outer boundary lines may be replaced with other black line symbols, such as symbol 516 (fence), 518 (impassable fence), 513 (wall) or 515 (impassable wall) if the feature is so close to the road edge that it cannot practically be shown as a separate symbol.</description>
-                <line_symbol color="3" line_width="530" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
-                    <borders>
-                        <border color="4" width="140" shift="70" dash_length="2000" break_length="1000"/>
-                    </borders>
-                </line_symbol>
-            </symbol>
-            <symbol type="16" id="113" code="502.2" name="Road with two carriageways">
+            <symbol type="16" id="106" code="502.1" name="Road with two carriageways">
                 <description>A road with two carriageways can be represented using two wide road symbols side by side, keeping only one of the road edges in the middle. The width of the symbol should be drawn to scale but not smaller than the minimum width. The outer boundary lines may be replaced with other black line symbols, such as symbol 516 (fence), 518 (impassable fence), 513 (wall) or 515 (impassable wall) if the feature is so close to the road edge that it cannot practically be shown as a separate symbol.</description>
                 <combined_symbol parts="2">
                     <part private="true">
@@ -2584,38 +2510,38 @@ The width should be drawn to scale, but not smaller than the minimum width. The 
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="2" id="114" code="503" name="Road">
+            <symbol type="2" id="107" code="503" name="Road">
                 <description>A maintained road suitable for motor vehicles in all weather. Width less than 5 m.</description>
                 <line_symbol color="2" line_width="350" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="115" code="504" name="Vehicle track">
+            <symbol type="2" id="108" code="504" name="Vehicle track">
                 <description>A track or poorly maintained road suitable for vehicles only when travelling slowly.</description>
                 <line_symbol color="2" line_width="350" minimum_length="6250" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="3000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="116" code="505" name="Footpath">
+            <symbol type="2" id="109" code="505" name="Footpath">
                 <description>An easily runnable path, bicycle track or old vehicle track.</description>
                 <line_symbol color="2" line_width="250" minimum_length="4250" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="117" code="506" name="Small footpath">
+            <symbol type="2" id="110" code="506" name="Small footpath">
                 <description>A runnable small path or (temporary) forest extraction track which can be followed at competition speed.</description>
                 <line_symbol color="2" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="118" code="507" name="Less distinct small footpath">
+            <symbol type="2" id="111" code="507" name="Less distinct small footpath">
                 <description>A runnable less distinct / visible small path or forestry extraction track.</description>
                 <line_symbol color="2" line_width="180" minimum_length="5300" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="1000" break_length="800" dashes_in_group="2" in_group_break_length="250" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="119" code="508" name="Narrow ride">
+            <symbol type="2" id="112" code="508" name="Narrow ride">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 Runnability: the same runnability as the surroundings.
 </description>
                 <line_symbol color="2" line_width="140" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="16" id="120" code="508.1" name="Narrow ride, yellow background">
+            <symbol type="16" id="113" code="508.1" name="Narrow ride, yellow background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: easy running.</description>
                 <combined_symbol parts="2">
-                    <part symbol="119"/>
+                    <part symbol="112"/>
                     <part private="true">
                         <symbol type="2" code="508.1.1" name="Yellow background">
                             <line_symbol color="17" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2623,12 +2549,12 @@ Runnability: easy running.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="121" code="508.2" name="Narrow ride, green 20% background">
+            <symbol type="16" id="114" code="508.2" name="Narrow ride, green 20% background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: slow running.</description>
                 <combined_symbol parts="2">
-                    <part symbol="119"/>
+                    <part symbol="112"/>
                     <part private="true">
                         <symbol type="2" code="508.2.1" name="Green 20% background">
                             <line_symbol color="16" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2636,12 +2562,12 @@ Runnability: slow running.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="122" code="508.3" name="Narrow ride, green 50% background">
+            <symbol type="16" id="115" code="508.3" name="Narrow ride, green 50% background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: walk.</description>
                 <combined_symbol parts="2">
-                    <part symbol="119"/>
+                    <part symbol="112"/>
                     <part private="true">
                         <symbol type="2" code="508.3.1" name="Green 50% background">
                             <line_symbol color="15" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2649,12 +2575,12 @@ Runnability: walk.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="123" code="508.4" name="Narrow ride, white background">
+            <symbol type="16" id="116" code="508.4" name="Narrow ride, white background">
                 <description>A forest ride or a prominent trace (forestry extraction track, sandy track, ski track) through the terrain which does not have a distinct runnable path along it. The definition of the symbol must be given on the map.
 The definition of the symbol must be given on the map.
 Runnability: normal runnability.</description>
                 <combined_symbol parts="2">
-                    <part symbol="119"/>
+                    <part symbol="112"/>
                     <part private="true">
                         <symbol type="2" code="508.4.1" name="White background">
                             <line_symbol color="13" line_width="450" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
@@ -2662,7 +2588,7 @@ Runnability: normal runnability.</description>
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="16" id="124" code="509" name="Railway">
+            <symbol type="16" id="117" code="509" name="Railway">
                 <description>A railway or other kind of railed track.
 If it is forbidden to run along the railway, it shall be combined with the overprint symbol for forbidden route. If it is forbidden to cross the railway, it must be combined with a symbol for forbidden area.</description>
                 <combined_symbol parts="2">
@@ -2678,7 +2604,7 @@ If it is forbidden to run along the railway, it shall be combined with the overp
                     </part>
                 </combined_symbol>
             </symbol>
-            <symbol type="2" id="125" code="510" name="Power line">
+            <symbol type="2" id="118" code="510" name="Power line">
                 <description>Power line, cableway or skilift. The bars show the exact location of the pylons. The line may be broken to improve legibility.
 </description>
                 <line_symbol color="2" line_width="140" minimum_length="5000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2704,7 +2630,7 @@ If it is forbidden to run along the railway, it shall be combined with the overp
                     </dash_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="126" code="511" name="Major power line, minimum width">
+            <symbol type="2" id="119" code="511" name="Major power line, minimum width">
                 <description>Major power lines should be drawn with a double line. The gap between the lines may indicate the extent of the powerline.
 The lines may be broken to improve legibility. Very large carrying masts shall be represented in plan shape using symbol 521 (building) or with symbol 524 (high tower).</description>
                 <line_symbol color="-1" line_width="400" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2733,7 +2659,7 @@ The lines may be broken to improve legibility. Very large carrying masts shall b
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="127" code="511.1" name="Major power line">
+            <symbol type="2" id="120" code="511.1" name="Major power line">
                 <description>Major power lines should be drawn with a double line. The gap between the lines may indicate the extent of the powerline.
 The lines may be broken to improve legibility. Very large carrying masts shall be represented in plan shape using symbol 521 (building) or with symbol 524 (high tower).</description>
                 <line_symbol color="-1" line_width="1600" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2779,7 +2705,7 @@ The lines may be broken to improve legibility. Very large carrying masts shall b
                     </borders>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="128" code="512" name="Bridge / tunnel">
+            <symbol type="2" id="121" code="512" name="Bridge / tunnel">
                 <description>Bridges and tunnels are represented using the same basic symbols.
 If it is not possible to get through a tunnel (or under a bridge), it shall be omitted.
 Small bridges connected to a track/path are shown by centring a track dash on the crossing. Tracks/paths are broken for water course crossings without bridges.
@@ -2829,7 +2755,7 @@ Small bridges connected to a track/path are shown by centring a track dash on th
                     </end_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="129" code="512.0.1" name="Bridge / tunnel, minimum size">
+            <symbol type="1" id="122" code="512.0.1" name="Bridge / tunnel, minimum size">
                 <description>Bridges and tunnels are represented using the same basic symbols.
 If it is not possible to get through a tunnel (or under a bridge), it shall be omitted.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -2851,7 +2777,7 @@ If it is not possible to get through a tunnel (or under a bridge), it shall be o
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="130" code="512.1" name="Footbridge">
+            <symbol type="1" id="123" code="512.1" name="Footbridge">
                 <description>A small footbridge with no path leading to it is represented with a single dash.
 Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm over both sides of the stream!</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
@@ -2871,7 +2797,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="131" code="513" name="Wall">
+            <symbol type="2" id="124" code="513" name="Wall">
                 <description>A significant wall of stone, concrete, wood or other materials. Minimum height: 1 m.</description>
                 <line_symbol color="2" line_width="140" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -2881,7 +2807,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="132" code="514" name="Ruined stone wall">
+            <symbol type="2" id="125" code="514" name="Ruined stone wall">
                 <description>A ruined or less distinct wall. Minimum height 0.5 m.</description>
                 <line_symbol color="2" line_width="140" minimum_length="3650" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="2500" end_length="1250" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="350" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -2891,7 +2817,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="133" code="515" name="Impassable wall">
+            <symbol type="2" id="126" code="515" name="Impassable wall">
                 <description>An impassable or uncrossable wall, normally more than 1.5 m high.</description>
                 <line_symbol color="2" line_width="250" minimum_length="3000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="3000" end_length="1500" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="2" mid_symbol_distance="800">
                     <mid_symbol>
@@ -2901,7 +2827,7 @@ Note: if the stream is wider than 0.25mm, adjust this symbol so it extends 0.5mm
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="134" code="516" name="Fence">
+            <symbol type="2" id="127" code="516" name="Fence">
                 <description>A wooden or wire fence less than ca. 1.5 m high.
 If the fence forms an enclosed area, tags should be placed inside.</description>
                 <line_symbol color="2" line_width="140" minimum_length="1500" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2927,7 +2853,7 @@ If the fence forms an enclosed area, tags should be placed inside.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="135" code="517" name="Ruined fence">
+            <symbol type="2" id="128" code="517" name="Ruined fence">
                 <description>A ruined or less distinct fence. If the fence forms an enclosed area, tags should be placed inside.</description>
                 <line_symbol color="2" line_width="140" minimum_length="3650" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="2500" end_length="1250" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="2000" break_length="350" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -2952,7 +2878,7 @@ If the fence forms an enclosed area, tags should be placed inside.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="136" code="518" name="Impassable fence">
+            <symbol type="2" id="129" code="518" name="Impassable fence">
                 <description>An impassable or uncrossable fence, normally more than 1.5 m high.
 If the fence forms an enclosed area, tags should be placed inside.</description>
                 <line_symbol color="2" line_width="250" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2500" end_length="1250" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
@@ -2992,7 +2918,7 @@ If the fence forms an enclosed area, tags should be placed inside.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="137" code="519" name="Crossing point">
+            <symbol type="1" id="130" code="519" name="Crossing point">
                 <description>A way through or over a wall, fence or other linear feature, including a gate or stile.
 For impassable features, the line shall be broken at the crossing point. For passable features, the line shall not be broken if passing involves a degree of climb.
 </description>
@@ -3027,33 +2953,33 @@ For impassable features, the line shall be broken at the crossing point. For pas
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="4" id="138" code="520.0" name="Area that shall not be entered">
+            <symbol type="4" id="131" code="520.0" name="Area that shall not be entered">
                 <description>An out-of-bounds area is a feature such as a private house, a garden, a factory or another industrial area. Only contours and prominent features such as railways and large buildings shall be shown inside an out-of-bounds area.
 The area shall be discontinued where a path or track goes through. Out-of-bounds areas should be bounded by the black boundary line or another black line symbol (e.g. fence).
 </description>
                 <area_symbol inner_color="12" min_area="1000" patterns="0"/>
             </symbol>
-            <symbol type="2" id="139" code="520.0.1" name="Out of bounds area, bounding line">
+            <symbol type="2" id="132" code="520.0.1" name="Out of bounds area, bounding line">
                 <description>A bounding line may be drawn with 520.0 if there is no natural boundary.</description>
                 <line_symbol color="2" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="140" code="520.1" name="Area that shall not be entered, alternative">
+            <symbol type="4" id="133" code="520.1" name="Area that shall not be entered, alternative">
                 <description>An out-of-bounds area is a feature such as a private house, a garden, a factory or another industrial area. Only contours and prominent features such as railways and large buildings shall be shown inside an out-of-bounds area.
 Vertical black stripes may be used for areas where it is important to show a complete representation of the terrain (e.g. when a part of the forest is out-of-bounds). The area shall be discontinued where a path or track goes through. Out-of-bounds areas should be bounded by the black boundary line or another black line symbol (e.g. fence).</description>
                 <area_symbol inner_color="-1" min_area="1000" patterns="1">
                     <pattern type="1" angle="1.5708" line_spacing="750" line_offset="0" offset_along_line="0" color="2" line_width="250"/>
                 </area_symbol>
             </symbol>
-            <symbol type="2" id="141" code="520.1.1" name="Out of bounds area, alternative bounding line">
+            <symbol type="2" id="134" code="520.1.1" name="Out of bounds area, alternative bounding line">
                 <description>A bounding line may be drawn with 520.1 if there is no natural boundary.</description>
                 <line_symbol color="2" line_width="350" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="142" code="521" name="Building">
+            <symbol type="4" id="135" code="521" name="Building">
                 <description>A building is shown with its ground plan so far as the scale permits.
 Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m). Buildings within forbidden areas are generalised. Areas totally contained within a building shall not be mapped (they shall be represented as being part of the building). Minimum gap indicating a passage between buildings and between buildings and other impassable features should be 0.25 mm.</description>
                 <area_symbol inner_color="2" min_area="300" patterns="0"/>
             </symbol>
-            <symbol type="1" id="143" code="521.0.1" name="Building, minimum size">
+            <symbol type="1" id="136" code="521.0.1" name="Building, minimum size">
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
                         <symbol type="4" code="">
@@ -3074,43 +3000,43 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="16" id="144" code="521.1" name="Large building with outline">
+            <symbol type="16" id="137" code="521.1" name="Large building with outline">
                 <description>A building is shown with its ground plan so far as the scale permits.
 Buildings larger than 75 m x 75 m may be represented with a dark grey infill in urban areas.
 Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m). Buildings within forbidden areas are generalised. Areas totally contained within a building shall not be mapped (they shall be represented as being part of the building). Minimum gap indicating a passage between buildings and between buildings and other impassable features should be 0.25 mm.</description>
                 <combined_symbol parts="2">
-                    <part symbol="145"/>
-                    <part symbol="146"/>
+                    <part symbol="138"/>
+                    <part symbol="139"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="145" code="521.1.1" name="Large building">
+            <symbol type="4" id="138" code="521.1.1" name="Large building">
                 <description>Buildings larger than 75 m x 75 m may be represented with a dark grey infill in urban areas.</description>
                 <area_symbol inner_color="6" min_area="0" patterns="0"/>
             </symbol>
-            <symbol type="2" id="146" code="521.1.2" name="Large building outline">
+            <symbol type="2" id="139" code="521.1.2" name="Large building outline">
                 <description>A black line surrounds the symbol 521.1.1.</description>
                 <line_symbol color="2" line_width="200" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="16" id="147" code="522" name="Canopy with outline">
+            <symbol type="16" id="140" code="522" name="Canopy with outline">
                 <description>An accessible and runnable area with roof.</description>
                 <combined_symbol parts="2">
-                    <part symbol="148"/>
-                    <part symbol="149"/>
+                    <part symbol="141"/>
+                    <part symbol="142"/>
                 </combined_symbol>
             </symbol>
-            <symbol type="4" id="148" code="522.0.1" name="Canopy">
+            <symbol type="4" id="141" code="522.0.1" name="Canopy">
                 <description>An accessible and runnable area with roof.</description>
                 <area_symbol inner_color="8" min_area="400" patterns="0"/>
             </symbol>
-            <symbol type="2" id="149" code="522.0.2" name="Canopy outline">
+            <symbol type="2" id="142" code="522.0.2" name="Canopy outline">
                 <description>A black line surrounds the symbol 522.0.1.</description>
                 <line_symbol color="2" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="2" id="150" code="523" name="Ruin">
+            <symbol type="2" id="143" code="523" name="Ruin">
                 <description>A ruined building. The ground plan of a ruin is shown to scale, down to the minimum size.</description>
                 <line_symbol color="2" line_width="160" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" dashed="true" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="500" break_length="250" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="1" id="151" code="523.0.1" name="Ruin, minimum size">
+            <symbol type="1" id="144" code="523.0.1" name="Ruin, minimum size">
                 <description>Ruins that are so small that they cannot be drawn to scale may be represented using a solid line.</description>
                 <point_symbol rotatable="true" inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="1">
                     <element>
@@ -3132,7 +3058,7 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="152" code="524" name="High tower">
+            <symbol type="1" id="145" code="524" name="High tower">
                 <description>A high tower or large pylon. If it is in a forest, it must be visible above the level of the surrounding forest.</description>
                 <point_symbol inner_radius="400" inner_color="2" outer_width="0" outer_color="-1" elements="2">
                     <element>
@@ -3165,7 +3091,7 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="153" code="525" name="Small tower">
+            <symbol type="1" id="146" code="525" name="Small tower">
                 <description>An obvious small tower, platform or seat.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
                     <element>
@@ -3198,7 +3124,7 @@ Passages through buildings must have a minimum width of 0.3 mm (footprint 4.5 m)
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="154" code="526" name="Cairn">
+            <symbol type="1" id="147" code="526" name="Cairn">
                 <description>A prominent cairn, memorial stone, boundary stone or trigonometric point.
 Minimum height: 0.5 m.</description>
                 <point_symbol inner_radius="70" inner_color="2" outer_width="0" outer_color="-1" elements="1">
@@ -3214,7 +3140,7 @@ Minimum height: 0.5 m.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="155" code="527" name="Fodder rack">
+            <symbol type="1" id="148" code="527" name="Fodder rack">
                 <description>A fodder rack, which is free standing or attached to a tree.
 Location is at the centre of gravity of the symbol.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
@@ -3249,7 +3175,7 @@ Location is at the centre of gravity of the symbol.</description>
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="156" code="528" name="Prominent line feature">
+            <symbol type="2" id="149" code="528" name="Prominent line feature">
                 <description>A prominent man-made line feature. For example, a low pipeline (gas, water, oil, heat, etc.) or a bobsleigh/skeleton track that is clearly visible. The definition of the symbol must be given on the map.</description>
                 <line_symbol color="2" line_width="140" minimum_length="1500" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0">
                     <mid_symbol>
@@ -3288,7 +3214,7 @@ Location is at the centre of gravity of the symbol.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="2" id="157" code="529" name="Prominent impassable line feature">
+            <symbol type="2" id="150" code="529" name="Prominent impassable line feature">
                 <description>An impassable man-made line feature. For example, a high pipeline (gas, water, oil, heat, etc.) or a bobsleigh/skeleton track. The definition of the symbol must be given on the map.</description>
                 <line_symbol color="2" line_width="250" minimum_length="2000" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="2000" end_length="1000" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="2" mid_symbol_distance="600">
                     <mid_symbol>
@@ -3327,13 +3253,13 @@ Location is at the centre of gravity of the symbol.</description>
                     </mid_symbol>
                 </line_symbol>
             </symbol>
-            <symbol type="1" id="158" code="530" name="Prominent man-made feature – ring">
+            <symbol type="1" id="151" code="530" name="Prominent man-made feature – ring">
                 <description>Special man-made features are shown with these symbols. The definition of the
 symbols must be given in each case in the map legend.
 </description>
                 <point_symbol inner_radius="240" inner_color="-1" outer_width="160" outer_color="2" elements="0"/>
             </symbol>
-            <symbol type="1" id="159" code="531" name="Prominent man-made feature – x">
+            <symbol type="1" id="152" code="531" name="Prominent man-made feature – x">
                 <description>Special man-made features are shown with these symbols. The definition of the
 symbols must be given in each case in the map legend.
 </description>
@@ -3368,30 +3294,30 @@ symbols must be given in each case in the map legend.
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="2" id="160" code="601.1" name="Magnetic north line">
+            <symbol type="2" id="153" code="601.1" name="Magnetic north line">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.
 </description>
                 <line_symbol color="2" line_width="100" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="161" code="601.1.1" name="North lines pattern">
+            <symbol type="4" id="154" code="601.1.1" name="North lines pattern">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="20000" line_offset="0" offset_along_line="0" color="2" line_width="100"/>
                 </area_symbol>
             </symbol>
-            <symbol type="2" id="162" code="601.2" name="Magnetic north line, blue">
+            <symbol type="2" id="155" code="601.2" name="Magnetic north line, blue">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.</description>
                 <line_symbol color="10" line_width="180" minimum_length="0" join_style="1" cap_style="0" pointed_cap_length="1000" segment_length="4000" end_length="0" show_at_least_one_symbol="true" minimum_mid_symbol_count="0" minimum_mid_symbol_count_when_closed="0" dash_length="4000" break_length="1000" dashes_in_group="1" in_group_break_length="500" mid_symbols_per_spot="1" mid_symbol_distance="0"/>
             </symbol>
-            <symbol type="4" id="163" code="601.2.1" name="North lines pattern, blue">
+            <symbol type="4" id="156" code="601.2.1" name="North lines pattern, blue">
                 <description>Magnetic north lines are lines placed on the map pointing to magnetic north, parallel to the sides of the paper. Their spacing on the map shall be 20 mm on the map which represents 300 m on the ground at the scale of 1:15 000. If the map is enlarged to 1:10 000, the spacing of the lines will be 30 mm on the map. North lines shall be broken to improve the legibility of the map, for instance where they would obscure small features. In areas with very few water features, blue lines may be used.
 </description>
                 <area_symbol inner_color="-1" min_area="0" patterns="1">
                     <pattern type="1" angle="1.5708" rotatable="true" line_spacing="20000" line_offset="0" offset_along_line="0" color="10" line_width="180"/>
                 </area_symbol>
             </symbol>
-            <symbol type="1" id="164" code="602" name="Registration mark">
+            <symbol type="1" id="157" code="602" name="Registration mark">
                 <description>At least three registration marks should be placed within the frame of a map in a non-symmetrical position. These can be used for course overprinting when overprinting on already printed maps. In addition, it allows a check of colour registration when printing colours separately.</description>
                 <point_symbol inner_radius="1000" inner_color="-1" outer_width="0" outer_color="-1" elements="2">
                     <element>
@@ -3424,18 +3350,18 @@ symbols must be given in each case in the map legend.
                     </element>
                 </point_symbol>
             </symbol>
-            <symbol type="1" id="165" code="603.0" name="Spot height, dot">
+            <symbol type="1" id="158" code="603.0" name="Spot height, dot">
                 <description>Spot heights are used for the rough assessment of height differences. The height is given to the nearest metre. Water levels are given without the dot. Spot heights must only be used where they do not conflict with other symbols.</description>
                 <point_symbol inner_radius="150" inner_color="2" outer_width="0" outer_color="-1" elements="0"/>
             </symbol>
-            <symbol type="8" id="166" code="603.1" name="Spot height, text">
+            <symbol type="8" id="159" code="603.1" name="Spot height, text">
                 <description>Spot heights are used for the rough assessment of height differences. The height is given to the nearest metre. Water levels are given without the dot. Spot heights must only be used where they do not conflict with other symbols.</description>
                 <text_symbol icon_text="321">
                     <font family="Arial" size="2180"/>
                     <text color="2" line_spacing="1" paragraph_spacing="0" character_spacing="0" kerning="true"/>
                 </text_symbol>
             </symbol>
-            <symbol type="1" id="167" code="999" name="OpenOrienteering Logo">
+            <symbol type="1" id="160" code="999" name="OpenOrienteering Logo">
                 <description>The OpenOrienteering Logo.</description>
                 <point_symbol inner_radius="250" inner_color="-1" outer_width="0" outer_color="-1" elements="30">
                     <element>
@@ -7375,8 +7301,8 @@ symbols must be given in each case in the map legend.
         </symbols>
         <parts count="1" current="0">
             <part name="default layer">
-                <objects count="33">
-                    <object type="1" symbol="86">
+                <objects count="45">
+                    <object type="1" symbol="81">
                         <coords count="5">
                             <coord x="-12148" y="-34717"/>
                             <coord x="-10325" y="-35275"/>
@@ -7388,7 +7314,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="89">
+                    <object type="1" symbol="84">
                         <coords count="13">
                             <coord x="-4122" y="-32241" flags="1"/>
                             <coord x="-3549" y="-32169"/>
@@ -7408,7 +7334,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="51">
+                    <object type="1" symbol="46">
                         <coords count="13">
                             <coord x="-5907" y="-30556" flags="1"/>
                             <coord x="-6149" y="-30883"/>
@@ -7430,11 +7356,11 @@ symbols must be given in each case in the map legend.
                     </object>
                     <object type="1" symbol="0">
                         <coords count="26">
-                            <coord x="-1745" y="-29497" flags="1"/>
-                            <coord x="-3072" y="-28612"/>
-                            <coord x="-3763" y="-28011"/>
+                            <coord x="909" y="-29961" flags="1"/>
+                            <coord x="-1365" y="-28484"/>
+                            <coord x="-2714" y="-28197"/>
                             <coord x="-5340" y="-27771" flags="1"/>
-                            <coord x="-6044" y="-27663"/>
+                            <coord x="-6043" y="-27657"/>
                             <coord x="-6463" y="-27781"/>
                             <coord x="-7084" y="-28131" flags="1"/>
                             <coord x="-7317" y="-28262"/>
@@ -7461,12 +7387,12 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="0" symbol="37">
+                    <object type="0" symbol="33">
                         <coords count="1">
                             <coord x="-11057" y="-29929"/>
                         </coords>
                     </object>
-                    <object type="1" symbol="78">
+                    <object type="1" symbol="73">
                         <coords count="13">
                             <coord x="-6272" y="-31470" flags="1"/>
                             <coord x="-5994" y="-30997"/>
@@ -7488,11 +7414,11 @@ symbols must be given in each case in the map legend.
                     </object>
                     <object type="1" symbol="0">
                         <coords count="17">
-                            <coord x="-2482" y="-31043" flags="1"/>
-                            <coord x="-3296" y="-30560"/>
-                            <coord x="-3671" y="-30244"/>
+                            <coord x="-109" y="-32298" flags="1"/>
+                            <coord x="-1870" y="-31189"/>
+                            <coord x="-3079" y="-30532"/>
                             <coord x="-4549" y="-29893" flags="1"/>
-                            <coord x="-5491" y="-29516"/>
+                            <coord x="-5480" y="-29489"/>
                             <coord x="-6308" y="-29204"/>
                             <coord x="-7084" y="-29857" flags="1"/>
                             <coord x="-8116" y="-30724"/>
@@ -7510,7 +7436,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="89">
+                    <object type="1" symbol="84">
                         <coords count="9">
                             <coord x="-7841" y="-28945" flags="1"/>
                             <coord x="-8577" y="-28172"/>
@@ -7526,7 +7452,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="78">
+                    <object type="1" symbol="73">
                         <coords count="13">
                             <coord x="-9627" y="-33434" flags="1"/>
                             <coord x="-8651" y="-33149"/>
@@ -7546,7 +7472,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="85">
+                    <object type="1" symbol="80">
                         <coords count="13">
                             <coord x="-4627" y="-32516" flags="1"/>
                             <coord x="-4217" y="-32891"/>
@@ -7566,7 +7492,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="75">
+                    <object type="1" symbol="70">
                         <coords count="13">
                             <coord x="-3518" y="-31114" flags="1"/>
                             <coord x="-3041" y="-31397"/>
@@ -7586,7 +7512,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="57">
+                    <object type="1" symbol="52">
                         <coords count="13">
                             <coord x="-3103" y="-34915" flags="1"/>
                             <coord x="-3401" y="-35395"/>
@@ -7606,7 +7532,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="54">
+                    <object type="1" symbol="49">
                         <coords count="13">
                             <coord x="-6305" y="-35033" flags="1"/>
                             <coord x="-6629" y="-34607"/>
@@ -7626,28 +7552,37 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="0" symbol="36">
+                    <object type="0" symbol="32">
                         <coords count="1">
                             <coord x="-11507" y="-30414"/>
                         </coords>
                     </object>
-                    <object type="1" symbol="85">
-                        <coords count="28">
+                    <object type="1" symbol="80">
+                        <coords count="47">
+                            <coord x="-13343" y="-32922" flags="1"/>
+                            <coord x="-13223" y="-32892"/>
+                            <coord x="-13169" y="-32847"/>
                             <coord x="-13079" y="-32763" flags="1"/>
                             <coord x="-11281" y="-31121"/>
                             <coord x="-9979" y="-30533"/>
                             <coord x="-7571" y="-30168" flags="1"/>
                             <coord x="-6461" y="-30000"/>
-                            <coord x="-5720" y="-29683"/>
+                            <coord x="-5795" y="-29827"/>
                             <coord x="-4765" y="-30274" flags="1"/>
-                            <coord x="-4023" y="-30734"/>
-                            <coord x="-3154" y="-31515"/>
-                            <coord x="-2647" y="-30804" flags="1"/>
-                            <coord x="-2207" y="-30188"/>
-                            <coord x="-1448" y="-29443"/>
-                            <coord x="-2065" y="-29003" flags="1"/>
-                            <coord x="-4137" y="-27523"/>
-                            <coord x="-5862" y="-27093"/>
+                            <coord x="-3632" y="-30766"/>
+                            <coord x="-3146" y="-31177"/>
+                            <coord x="-2344" y="-32551" flags="1"/>
+                            <coord x="-1932" y="-33257"/>
+                            <coord x="-276" y="-32794"/>
+                            <coord x="-70" y="-32506" flags="1"/>
+                            <coord x="370" y="-31890"/>
+                            <coord x="1668" y="-29163"/>
+                            <coord x="1051" y="-28723" flags="1"/>
+                            <coord x="75" y="-28027"/>
+                            <coord x="-1443" y="-27494"/>
+                            <coord x="-3158" y="-27492" flags="1"/>
+                            <coord x="-5085" y="-27490"/>
+                            <coord x="-7016" y="-27419"/>
                             <coord x="-8313" y="-27785" flags="1"/>
                             <coord x="-11008" y="-28547"/>
                             <coord x="-12929" y="-28919"/>
@@ -7657,16 +7592,26 @@ symbols must be given in each case in the map legend.
                             <coord x="-14455" y="-32922" flags="1"/>
                             <coord x="-14078" y="-33157"/>
                             <coord x="-13775" y="-33030"/>
-                            <coord x="-13343" y="-32922" flags="1"/>
-                            <coord x="-13223" y="-32892"/>
-                            <coord x="-13169" y="-32847"/>
-                            <coord x="-13079" y="-32763" flags="18"/>
+                            <coord x="-13343" y="-32922" flags="18"/>
+                            <coord x="-2316" y="-30510" flags="1"/>
+                            <coord x="-3176" y="-30125"/>
+                            <coord x="-3848" y="-29235"/>
+                            <coord x="-3462" y="-28375" flags="1"/>
+                            <coord x="-3076" y="-27515"/>
+                            <coord x="-1875" y="-27858"/>
+                            <coord x="-1016" y="-28244" flags="1"/>
+                            <coord x="-157" y="-28630"/>
+                            <coord x="324" y="-29412"/>
+                            <coord x="-62" y="-30272" flags="1"/>
+                            <coord x="-447" y="-31131"/>
+                            <coord x="-1456" y="-30895"/>
+                            <coord x="-2316" y="-30510" flags="18"/>
                         </coords>
                         <pattern rotation="0">
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="138">
+                    <object type="1" symbol="131">
                         <coords count="13">
                             <coord x="-7716" y="-35085" flags="1"/>
                             <coord x="-8039" y="-34658"/>
@@ -7686,16 +7631,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="112">
-                        <coords count="2">
-                            <coord x="-14964" y="-26565"/>
-                            <coord x="-1665" y="-26490"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="103">
+                    <object type="1" symbol="97">
                         <coords count="7">
                             <coord x="-6587" y="-30111" flags="1"/>
                             <coord x="-6805" y="-30813"/>
@@ -7709,13 +7645,13 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="4">
+                    <object type="1" symbol="2">
                         <coords count="17">
-                            <coord x="-1835" y="-30432" flags="1"/>
-                            <coord x="-2796" y="-29643"/>
-                            <coord x="-3320" y="-29167"/>
+                            <coord x="381" y="-31119" flags="1"/>
+                            <coord x="-1310" y="-29987"/>
+                            <coord x="-2609" y="-29387"/>
                             <coord x="-4531" y="-28885" flags="1"/>
-                            <coord x="-5587" y="-28639"/>
+                            <coord x="-5580" y="-28611"/>
                             <coord x="-6722" y="-28306"/>
                             <coord x="-7651" y="-29304" flags="1"/>
                             <coord x="-8215" y="-29911"/>
@@ -7733,7 +7669,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="63">
+                    <object type="1" symbol="58">
                         <coords count="8">
                             <coord x="-8827" y="-33831" flags="1"/>
                             <coord x="-8816" y="-33324"/>
@@ -7748,7 +7684,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="79">
+                    <object type="1" symbol="74">
                         <coords count="14">
                             <coord x="-12899" y="-26915"/>
                             <coord x="-9575" y="-26880"/>
@@ -7769,7 +7705,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="88">
+                    <object type="1" symbol="83">
                         <coords count="11">
                             <coord x="-12846" y="-28206"/>
                             <coord x="-9814" y="-27569"/>
@@ -7787,30 +7723,12 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="90">
-                        <coords count="2">
-                            <coord x="-9807" y="-27306"/>
-                            <coord x="-10815" y="-27306"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="90">
-                        <coords count="2">
-                            <coord x="-12840" y="-27325"/>
-                            <coord x="-11568" y="-27325"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="0" symbol="105">
+                    <object type="0" symbol="99">
                         <coords count="1">
                             <coord x="-4862" y="-32369"/>
                         </coords>
                     </object>
-                    <object type="1" symbol="81">
+                    <object type="1" symbol="76">
                         <coords count="13">
                             <coord x="-5518" y="-32833" flags="1"/>
                             <coord x="-5753" y="-32481"/>
@@ -7830,12 +7748,12 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="0" symbol="164">
+                    <object type="0" symbol="157">
                         <coords count="1">
                             <coord x="-3723" y="-27231"/>
                         </coords>
                     </object>
-                    <object type="1" symbol="111">
+                    <object type="1" symbol="105">
                         <coords count="2">
                             <coord x="-13197" y="-34711"/>
                             <coord x="-13216" y="-25002"/>
@@ -7844,7 +7762,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="6">
+                    <object type="1" symbol="4">
                         <coords count="13">
                             <coord x="-10002" y="-30005" flags="1"/>
                             <coord x="-10147" y="-29850"/>
@@ -7864,12 +7782,12 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="0" symbol="8" rotation="-2.32167">
+                    <object type="0" symbol="5" rotation="-2.32167">
                         <coords count="1">
                             <coord x="-10002" y="-29991"/>
                         </coords>
                     </object>
-                    <object type="1" symbol="95">
+                    <object type="1" symbol="89">
                         <coords count="2">
                             <coord x="-9016" y="-27286"/>
                             <coord x="-7481" y="-27278" flags="16"/>
@@ -7878,7 +7796,7 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="82">
+                    <object type="1" symbol="77">
                         <coords count="13">
                             <coord x="-6021" y="-32375" flags="1"/>
                             <coord x="-5611" y="-32750"/>
@@ -7898,10 +7816,187 @@ symbols must be given in each case in the map legend.
                             <coord x="0" y="0"/>
                         </pattern>
                     </object>
-                    <object type="1" symbol="104">
+                    <object type="1" symbol="98">
                         <coords count="2">
                             <coord x="-11753" y="-31627"/>
                             <coord x="-11758" y="-28986"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="112">
+                        <coords count="2">
+                            <coord x="-3681" y="-31114"/>
+                            <coord x="-2662" y="-27426" flags="16"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="113">
+                        <coords count="2">
+                            <coord x="-3182" y="-31394"/>
+                            <coord x="-1828" y="-27460"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="114">
+                        <coords count="2">
+                            <coord x="-2533" y="-31719"/>
+                            <coord x="-1016" y="-27433"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="115">
+                        <coords count="2">
+                            <coord x="-2071" y="-32056"/>
+                            <coord x="-169" y="-27772"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="116">
+                        <coords count="2">
+                            <coord x="-1479" y="-32352"/>
+                            <coord x="558" y="-28125"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="84">
+                        <coords count="17">
+                            <coord x="-3485" y="-28376" flags="1"/>
+                            <coord x="-3109" y="-28934"/>
+                            <coord x="-2284" y="-28519"/>
+                            <coord x="-1911" y="-29079" flags="1"/>
+                            <coord x="-1439" y="-29787"/>
+                            <coord x="-431" y="-30832"/>
+                            <coord x="10" y="-30105"/>
+                            <coord x="12" y="-30074" flags="1"/>
+                            <coord x="247" y="-29293"/>
+                            <coord x="-223" y="-28600"/>
+                            <coord x="-1016" y="-28244" flags="1"/>
+                            <coord x="-1864" y="-27863"/>
+                            <coord x="-3044" y="-27524"/>
+                            <coord x="-3446" y="-28341" flags="1"/>
+                            <coord x="-3455" y="-28359"/>
+                            <coord x="-3496" y="-28359"/>
+                            <coord x="-3485" y="-28376" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="88">
+                        <coords count="19">
+                            <coord x="-3467" y="-28386"/>
+                            <coord x="-3463" y="-28377" flags="1"/>
+                            <coord x="-3847" y="-29237"/>
+                            <coord x="-3175" y="-30125"/>
+                            <coord x="-2316" y="-30510" flags="1"/>
+                            <coord x="-1456" y="-30895"/>
+                            <coord x="-447" y="-31131"/>
+                            <coord x="-62" y="-30272" flags="1"/>
+                            <coord x="-49" y="-30243"/>
+                            <coord x="-37" y="-30215"/>
+                            <coord x="-26" y="-30186"/>
+                            <coord x="-50" y="-30189" flags="1"/>
+                            <coord x="-517" y="-30742"/>
+                            <coord x="-1459" y="-29756"/>
+                            <coord x="-1911" y="-29079" flags="1"/>
+                            <coord x="-2281" y="-28524"/>
+                            <coord x="-3094" y="-28926"/>
+                            <coord x="-3475" y="-28391"/>
+                            <coord x="-3467" y="-28386" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="102">
+                        <coords count="5">
+                            <coord x="-13195" y="-27344"/>
+                            <coord x="-14245" y="-28101"/>
+                            <coord x="-14221" y="-29174"/>
+                            <coord x="-13195" y="-29843"/>
+                            <coord x="-13195" y="-27344" flags="18"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="89">
+                        <coords count="2">
+                            <coord x="-12840" y="-27325"/>
+                            <coord x="-11568" y="-27325"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="89">
+                        <coords count="2">
+                            <coord x="-9807" y="-27306"/>
+                            <coord x="-10815" y="-27306"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="47">
+                        <coords count="2">
+                            <coord x="721" y="-33653"/>
+                            <coord x="-5090" y="-30464"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="105">
+                        <coords count="2">
+                            <coord x="-14964" y="-26565"/>
+                            <coord x="-5684" y="-26604"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="156">
+                        <coords count="5">
+                            <coord x="-24396" y="-35893" flags="32"/>
+                            <coord x="-24260" y="-9966" flags="32"/>
+                            <coord x="-26742" y="-9953" flags="32"/>
+                            <coord x="-26878" y="-35880" flags="32"/>
+                            <coord x="-24396" y="-35893" flags="50"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="106">
+                        <coords count="2">
+                            <coord x="-4270" y="-26389"/>
+                            <coord x="1990" y="-26416" flags="16"/>
+                        </coords>
+                        <pattern rotation="0">
+                            <coord x="0" y="0"/>
+                        </pattern>
+                    </object>
+                    <object type="1" symbol="102">
+                        <coords count="6">
+                            <coord x="-5814" y="-26753"/>
+                            <coord x="-4266" y="-26780"/>
+                            <coord x="-4257" y="-25999"/>
+                            <coord x="-4567" y="-25994"/>
+                            <coord x="-5815" y="-26455"/>
+                            <coord x="-5814" y="-26753" flags="18"/>
                         </coords>
                         <pattern rotation="0">
                             <coord x="0" y="0"/>
@@ -7915,580 +8010,14 @@ symbols must be given in each case in the map legend.
         </templates>
         <view>
             <grid color="#646464" display="0" alignment="0" additional_rotation="0" unit="1" h_spacing="500" v_spacing="500" h_offset="0" v_offset="0" snapping_enabled="true"/>
-            <map_view zoom="5.65685" rotation="0" position_x="-12783" position_y="-27648">
+            <map_view zoom="12.0902" rotation="0" position_x="-6822" position_y="-30499">
                 <map opacity="1" visible="true"/>
                 <templates count="0"/>
             </map_view>
         </view>
     </barrier>
     <barrier version="6" required="0.6.0">
-        <undo>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="32"/>
-                </affected_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="0" symbol="2" rotation="2.6576">
-                        <coords count="1">
-                            <coord x="11402" y="-33571"/>
-                        </coords>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="0" symbol="2" rotation="2.6576">
-                        <coords count="1">
-                            <coord x="10001" y="-34045"/>
-                        </coords>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                    <ref object="31"/>
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="3">
-                    <object type="0" symbol="2" rotation="2.6576">
-                        <coords count="1">
-                            <coord x="10694" y="-33599"/>
-                        </coords>
-                    </object>
-                    <object type="0" symbol="1" rotation="2.6542">
-                        <coords count="1">
-                            <coord x="10042" y="-32490"/>
-                        </coords>
-                    </object>
-                    <object type="0" symbol="7" rotation="2.67766">
-                        <coords count="1">
-                            <coord x="10002" y="-34051"/>
-                        </coords>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="121">
-                        <coords count="2">
-                            <coord x="3726" y="-35657"/>
-                            <coord x="5735" y="-34383"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="32"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="33"/>
-                </affected_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                    <ref object="31"/>
-                    <ref object="31"/>
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="4">
-                    <object type="1" symbol="122">
-                        <coords count="2">
-                            <coord x="4575" y="-36902"/>
-                            <coord x="10489" y="-33421"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="119">
-                        <coords count="2">
-                            <coord x="5254" y="-32233"/>
-                            <coord x="8904" y="-36930"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="123">
-                        <coords count="2">
-                            <coord x="3471" y="-33959"/>
-                            <coord x="6838" y="-37807"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="121">
-                        <coords count="2">
-                            <coord x="3726" y="-35657"/>
-                            <coord x="8961" y="-32544"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="69">
-                        <coords count="2">
-                            <coord x="5874" y="-30966"/>
-                            <coord x="6325" y="-30916"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="69">
-                        <coords count="2">
-                            <coord x="5874" y="-30966"/>
-                            <coord x="6375" y="-30926"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="69">
-                        <coords count="2">
-                            <coord x="5874" y="-30966"/>
-                            <coord x="6575" y="-30936"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                    <ref object="30"/>
-                </affected_objects>
-                <contained_objects count="2">
-                    <object type="0" symbol="129" rotation="0">
-                        <coords count="1">
-                            <coord x="8075" y="-31975"/>
-                        </coords>
-                    </object>
-                    <object type="1" symbol="128">
-                        <coords count="2">
-                            <coord x="5528" y="-30957"/>
-                            <coord x="9801" y="-30985"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="30"/>
-                </affected_objects>
-            </step>
-            <step type="5">
-                <steps count="2">
-                    <step type="2">
-                        <affected_objects part="0">
-                            <ref object="30"/>
-                        </affected_objects>
-                        <contained_objects count="1">
-                            <object type="1" symbol="95">
-                                <coords count="2">
-                                    <coord x="-9836" y="-27291"/>
-                                    <coord x="-7481" y="-27278"/>
-                                </coords>
-                                <pattern rotation="0">
-                                    <coord x="0" y="0"/>
-                                </pattern>
-                            </object>
-                        </contained_objects>
-                    </step>
-                    <step type="1">
-                        <affected_objects part="0">
-                            <ref object="30"/>
-                        </affected_objects>
-                    </step>
-                </steps>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="85">
-                        <coords count="13">
-                            <coord x="-4627" y="-32516" flags="1"/>
-                            <coord x="-4217" y="-32891"/>
-                            <coord x="-4189" y="-33527"/>
-                            <coord x="-4564" y="-33938" flags="1"/>
-                            <coord x="-4939" y="-34348"/>
-                            <coord x="-5575" y="-34377"/>
-                            <coord x="-5986" y="-34001" flags="1"/>
-                            <coord x="-6396" y="-33627"/>
-                            <coord x="-6425" y="-32990"/>
-                            <coord x="-6049" y="-32579" flags="1"/>
-                            <coord x="-5675" y="-32169"/>
-                            <coord x="-5038" y="-32141"/>
-                            <coord x="-4627" y="-32516" flags="18"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="82">
-                        <coords count="13">
-                            <coord x="-4627" y="-32516" flags="1"/>
-                            <coord x="-4217" y="-32891"/>
-                            <coord x="-4189" y="-33527"/>
-                            <coord x="-4564" y="-33938" flags="1"/>
-                            <coord x="-4939" y="-34348"/>
-                            <coord x="-5575" y="-34377"/>
-                            <coord x="-5986" y="-34001" flags="1"/>
-                            <coord x="-6396" y="-33627"/>
-                            <coord x="-6425" y="-32990"/>
-                            <coord x="-6049" y="-32579" flags="1"/>
-                            <coord x="-5675" y="-32169"/>
-                            <coord x="-5038" y="-32141"/>
-                            <coord x="-4627" y="-32516" flags="18"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="31"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="82">
-                        <coords count="13">
-                            <coord x="-5922" y="-32375" flags="1"/>
-                            <coord x="-5512" y="-32750"/>
-                            <coord x="-5484" y="-33386"/>
-                            <coord x="-5859" y="-33797" flags="1"/>
-                            <coord x="-6234" y="-34207"/>
-                            <coord x="-6870" y="-34236"/>
-                            <coord x="-7281" y="-33860" flags="1"/>
-                            <coord x="-7691" y="-33486"/>
-                            <coord x="-7720" y="-32849"/>
-                            <coord x="-7344" y="-32438" flags="1"/>
-                            <coord x="-6970" y="-32028"/>
-                            <coord x="-6333" y="-32000"/>
-                            <coord x="-5922" y="-32375" flags="18"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="0">
-                <affected_objects part="0">
-                    <ref object="5"/>
-                    <ref object="10"/>
-                </affected_objects>
-                <contained_objects count="2">
-                    <object type="1" symbol="78">
-                        <coords count="13">
-                            <coord x="-6251" y="-31654" flags="1"/>
-                            <coord x="-5973" y="-31181"/>
-                            <coord x="-5365" y="-31023"/>
-                            <coord x="-4893" y="-31301" flags="1"/>
-                            <coord x="-4421" y="-31578"/>
-                            <coord x="-4262" y="-32186"/>
-                            <coord x="-4539" y="-32658" flags="1"/>
-                            <coord x="-4817" y="-33131"/>
-                            <coord x="-5425" y="-33289"/>
-                            <coord x="-5897" y="-33011" flags="1"/>
-                            <coord x="-6370" y="-32734"/>
-                            <coord x="-6528" y="-32127"/>
-                            <coord x="-6251" y="-31654" flags="18"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="75">
-                        <coords count="13">
-                            <coord x="-3497" y="-31298" flags="1"/>
-                            <coord x="-3020" y="-31581"/>
-                            <coord x="-2861" y="-32197"/>
-                            <coord x="-3144" y="-32675" flags="1"/>
-                            <coord x="-3427" y="-33152"/>
-                            <coord x="-4043" y="-33311"/>
-                            <coord x="-4521" y="-33028" flags="1"/>
-                            <coord x="-4998" y="-32745"/>
-                            <coord x="-5156" y="-32129"/>
-                            <coord x="-4874" y="-31651" flags="1"/>
-                            <coord x="-4591" y="-31174"/>
-                            <coord x="-3975" y="-31015"/>
-                            <coord x="-3497" y="-31298" flags="18"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="32"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="33"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="34"/>
-                </affected_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="34"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="111">
-                        <coords count="2">
-                            <coord x="-16925" y="-15416" flags="32"/>
-                            <coord x="-4359" y="-16177" flags="32"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="34"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="35"/>
-                </affected_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="35"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="110">
-                        <coords count="2">
-                            <coord x="-12329" y="-17491"/>
-                            <coord x="-9928" y="-15189"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="34"/>
-                    <ref object="33"/>
-                </affected_objects>
-                <contained_objects count="2">
-                    <object type="1" symbol="111">
-                        <coords count="2">
-                            <coord x="-16524" y="-15416"/>
-                            <coord x="-3558" y="-16457"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                    <object type="1" symbol="108">
-                        <coords count="5">
-                            <coord x="-14684" y="-18618" flags="32"/>
-                            <coord x="-7000" y="-18618" flags="32"/>
-                            <coord x="-7000" y="-12415" flags="32"/>
-                            <coord x="-14684" y="-12415" flags="32"/>
-                            <coord x="-14684" y="-18618" flags="50"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="33"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="34"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="35"/>
-                </affected_objects>
-            </step>
-            <step type="1">
-                <affected_objects part="0">
-                    <ref object="36"/>
-                </affected_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="36"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="123">
-                        <coords count="2">
-                            <coord x="-3839" y="-36749"/>
-                            <coord x="-3939" y="-30226"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="35"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="122">
-                        <coords count="3">
-                            <coord x="-2638" y="-31107"/>
-                            <coord x="-8461" y="-35949"/>
-                            <coord x="-9121" y="-35829"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="33"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="120">
-                        <coords count="2">
-                            <coord x="-8716" y="-33196"/>
-                            <coord x="-1613" y="-33337"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-            <step type="2">
-                <affected_objects part="0">
-                    <ref object="33"/>
-                </affected_objects>
-                <contained_objects count="1">
-                    <object type="1" symbol="121">
-                        <coords count="2">
-                            <coord x="-7841" y="-31847"/>
-                            <coord x="-1898" y="-34888"/>
-                        </coords>
-                        <pattern rotation="0">
-                            <coord x="0" y="0"/>
-                        </pattern>
-                    </object>
-                </contained_objects>
-            </step>
-        </undo>
+        <undo/>
         <redo/>
     </barrier>
 </map>


### PR DESCRIPTION
- removed minimum size symbols for features drawn with contour lines (101
  and 103)
- added earth bank (104) top line as separate symbol
- fixed start and end tag rendering on earth bank symbol (104)
- set element clipping options on broken ground symbol (113 and 114)
- fixed start and end tag rendering on cliff symbol (202)
- set "tag-less" version of cliff symbol (202) as preferred
- removed rounded-end variants of cliff symbol
- set element clipping for boulder fields and stony ground (208-212)
- removed reduced-size large boulder (205.1)
- removed white infill for trench (215)
- removed vegetation, fight minimum size symbol 410.0.1

A bit of additional rationale. The contour line based point symbols enforce the feature shape which is inappropriate. Earth bank and cliff symbols had OCAD-like rendering with no star and end tag line. OOM has tag lines at the line ends. Rounded end cliff lines are optional in the standard and are very easy to set in the editor hence do not deserve extra symbol. Reduced size large boulder is the same size as enlarged boulder. They cannot be visually distinguished. Advanced users can easily (re-)introduce the symbol if needed. The standard does not prescribe white infill between the lines of trench symbol.